### PR TITLE
fix: error message being displayed on start

### DIFF
--- a/gui/src/main/error-message.tsx
+++ b/gui/src/main/error-message.tsx
@@ -36,6 +36,11 @@ export const ErrorMessage: React.FC<ErrorMessageProps> = ({
           "px-8 py-3 rounded-r-xl text-xl backdrop-blur-sm pointer-events-none",
           "bg-[rgba(255,0,0,.125)]"
         )}
+        {...(errorMessage === null && {
+          style: {
+            opacity: 0,
+          },
+        })}
       >
         <Icon
           icon="material-symbols:warning-outline"


### PR DESCRIPTION
The error box was being rendered without any errorMessage specified