### PR TITLE
fix: gui renaming variables part 2

### DIFF
--- a/gui/src/main/machine.ts
+++ b/gui/src/main/machine.ts
@@ -9,16 +9,16 @@ import {
 import type { data, data as model } from "@@/go/models";
 
 export type MatchEvent = {
-  matchHistory: model.MatchHistory;
+  matchHistory: model.TrackingState;
 } & EventObject;
 
 type CFNMachineContext = {
-  playerInfo: data.PlayerInfo;
+  playerInfo: data.User;
   game?: "sfv" | "sf6";
   restore: boolean;
   isTracking: boolean;
   error: string;
-  matchHistory: model.MatchHistory;
+  matchHistory: model.TrackingState;
 };
 
 export const cfnMachine = createMachine(
@@ -30,7 +30,7 @@ export const cfnMachine = createMachine(
     context: <CFNMachineContext>{
       restore: false,
       isTracking: false,
-      matchHistory: <model.MatchHistory>{
+      matchHistory: <model.TrackingState>{
         cfn: "",
         wins: 0,
         losses: 0,
@@ -112,7 +112,7 @@ export const cfnMachine = createMachine(
       },
       startTracking: ({ playerInfo, restore, isTracking }) => {
         if (playerInfo && !isTracking) {
-          StartTracking(playerInfo.id, restore).then(() => {
+          StartTracking(playerInfo.code, restore).then(() => {
             isTracking = true;
           });
         }

--- a/gui/src/pages/history-page.tsx
+++ b/gui/src/pages/history-page.tsx
@@ -17,9 +17,9 @@ import { PageHeader } from "@/ui/page-header";
 export const HistoryPage: React.FC = () => {
   const { t } = useTranslation();
 
-  const [availablePlayers, setAvailablePlayers] = React.useState<model.PlayerInfo[]>([]);
-  const [selectedPlayer, setLog] = React.useState<model.PlayerInfo>();
-  const [matchLog, setMatchLog] = React.useState<model.MatchHistory[]>([]);
+  const [availablePlayers, setAvailablePlayers] = React.useState<model.User[]>([]);
+  const [selectedPlayer, setLog] = React.useState<model.User>();
+  const [matchLog, setMatchLog] = React.useState<model.TrackingState[]>([]);
 
   const [isSpecified, setSpecified] = React.useState(false);
   const [totalWinRate, setTotalWinRate] = React.useState<number | null>(null);
@@ -38,7 +38,7 @@ export const HistoryPage: React.FC = () => {
   }, []);
 
   React.useEffect(() => {
-    if (selectedPlayer && !matchLog) fetchLog(selectedPlayer.id);
+    if (selectedPlayer && !matchLog) fetchLog(selectedPlayer.code);
   }, [selectedPlayer, matchLog]);
 
   React.useEffect(() => {
@@ -72,7 +72,7 @@ export const HistoryPage: React.FC = () => {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               onClick={() =>
-                isSpecified ? fetchLog(selectedPlayer.id) : setLog(undefined)
+                isSpecified ? fetchLog(selectedPlayer.code) : setLog(undefined)
               }
               className="crumb-btn-dark mr-3"
             >
@@ -86,7 +86,7 @@ export const HistoryPage: React.FC = () => {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               onClick={() => {
-                ExportLogToCSV(selectedPlayer.id);
+                ExportLogToCSV(selectedPlayer.code);
                 OpenResultsDirectory();
               }}
               className="crumb-btn-dark mr-3"
@@ -101,7 +101,7 @@ export const HistoryPage: React.FC = () => {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               onClick={() => {
-                selectedPlayer && DeleteMatchLog(selectedPlayer.id);
+                selectedPlayer && DeleteMatchLog(selectedPlayer.code);
                 setTimeout(() => setMatchLog([]), 50);
                 setLog(undefined);
               }}
@@ -128,7 +128,7 @@ export const HistoryPage: React.FC = () => {
                 key={playerInfo.displayName}
                 onClick={() => {
                   setLog(playerInfo);
-                  fetchLog(playerInfo.id);
+                  fetchLog(playerInfo.code);
                 }}
               >
                 {playerInfo.displayName}

--- a/gui/src/pages/tracking/tracking-form.tsx
+++ b/gui/src/pages/tracking/tracking-form.tsx
@@ -30,8 +30,9 @@ export const TrackingForm: React.FC = () => {
     send({
       type: "submit",
       playerInfo: {
-        displayName: oldPlayers?.find((old) => old.code == playerIdInput) ?? playerIdInput,
-        id: playerIdInput,
+        displayName:
+          oldPlayers?.find((old) => old.code == playerIdInput) ?? playerIdInput,
+        code: playerIdInput,
       },
       restore: restoreRef.current && restoreRef.current.checked,
     });
@@ -81,15 +82,23 @@ export const TrackingForm: React.FC = () => {
           </div>
         )}
         <footer className="flex items-center w-full">
-          {oldPlayers && oldPlayers.some(old => old.code == playerIdInput) && (
-            <div className="group flex items-center">
-              <Checkbox ref={restoreRef} id="restore-session" />
-              <label htmlFor="restore-session" className="text-lg cursor-pointer text-gray-300 group-hover:text-white transition-colors">
-                {t("restoreSession")}
-              </label>
-            </div>
-          )}
-          <ActionButton type="submit" style={{ filter: "hue-rotate(-65deg)" }} className="ml-auto">         
+          {oldPlayers &&
+            oldPlayers.some((old) => old.code == playerIdInput) && (
+              <div className="group flex items-center">
+                <Checkbox ref={restoreRef} id="restore-session" />
+                <label
+                  htmlFor="restore-session"
+                  className="text-lg cursor-pointer text-gray-300 group-hover:text-white transition-colors"
+                >
+                  {t("restoreSession")}
+                </label>
+              </div>
+            )}
+          <ActionButton
+            type="submit"
+            style={{ filter: "hue-rotate(-65deg)" }}
+            className="ml-auto"
+          >
             {t("start")}
           </ActionButton>
         </footer>


### PR DESCRIPTION
This is a continuation of #36 after a premature merge of #37 .

Added bug fix missing in #36 . Where the submit event from tracking-form to the state machine was still using the cold "id" key instead of "code" to represent the user code. This caused the user code to be empty/undefined in various parts of the application.