### PR TITLE
Persist authentication across app instances

### DIFF
--- a/core/cmd.go
+++ b/core/cmd.go
@@ -125,7 +125,7 @@ func (ch *CommandHandler) ResultsJSONExist() bool {
 
 func (ch *CommandHandler) StartBrowser(ctx context.Context) {
 	ch.ctx = ctx
-	ch.browser = shared.NewBrowser(ctx, RunHeadless)
+	ch.browser, _ = shared.NewBrowser(ctx, RunHeadless)
 	ch.browser.CheckForVersionUpdate(AppVersion)
 	go shared.Serve(ctx)
 }

--- a/core/impl/sf6/auth.go
+++ b/core/impl/sf6/auth.go
@@ -25,14 +25,12 @@ func (t *SF6Tracker) Authenticate(email string, password string, dry bool) error
 
 	log.Print("Checking if already authed")
 	if strings.Contains(t.Page.MustInfo().URL, `cid.capcom.com/ja/mypage`) {
-		log.Print("Not authed, continuing with auth process")
+		log.Print("User already authed")
 		t.isAuthenticated = true
 		wails.EventsEmit(t.ctx, `initialized`, true)
 		return nil
 	}
 	log.Print("Not authed, continuing with auth process")
-
-
 
 	// Bypass age check
 	if strings.Contains(t.Page.MustInfo().URL, `agecheck`) {

--- a/core/impl/sf6/auth_test.go
+++ b/core/impl/sf6/auth_test.go
@@ -15,7 +15,7 @@ func TestSF6Authentication(t *testing.T) {
 	assert := assert.New(t)
 
 	ctx := context.Background()
-	browser := shared.NewBrowser(ctx, true)
+	browser, _ := shared.NewBrowser(ctx, true)
 	sf6Tracker := NewSF6Tracker(ctx, browser, nil)
 	err := sf6Tracker.Authenticate(os.Getenv(`CAP_ID_EMAIL`), os.Getenv(`CAP_ID_PASSWORD`), true)
 

--- a/core/impl/sf6/track.go
+++ b/core/impl/sf6/track.go
@@ -33,7 +33,6 @@ type SF6Tracker struct {
 	gainsMR          map[string]int
 	startingMR       map[string]int
 	currentCharacter string
-	cookie           string
 	*shared.Browser
 	*data.CFNTrackerRepository
 }
@@ -46,7 +45,6 @@ func NewSF6Tracker(ctx context.Context, browser *shared.Browser, trackerRepo *da
 		Browser:          browser,
 		stopTracking:     func() {},
 		currentCharacter: ``,
-		cookie:           ``,
 
 		// LP
 		gains:          make(map[string]int, 42),

--- a/core/impl/sfv/auth_test.go
+++ b/core/impl/sfv/auth_test.go
@@ -15,7 +15,7 @@ func TestSFVAuthentication(t *testing.T) {
 	assert := assert.New(t)
 
 	ctx := context.Background()
-	browser := shared.NewBrowser(ctx, true)
+	browser, _ := shared.NewBrowser(ctx, true)
 	sf5Tracker := NewSFVTracker(ctx, browser)
 	err := sf5Tracker.Authenticate(os.Getenv(`STEAM_USERNAME`), os.Getenv(`STEAM_PASSWORD`), true)
 


### PR DESCRIPTION
Now sets custom user data dir for the go-rod browser. This lets us reuse cookies and session so we don't have to re-auth everytime on app start.