### PR TITLE
chore: refactor tracking

### DIFF
--- a/core/builder.go
+++ b/core/builder.go
@@ -12,7 +12,7 @@ import (
 )
 
 type GameTracker interface {
-	Start(cfn string, restore bool, refreshInterval time.Duration) error
+	Start(ctx context.Context, cfn string, restore bool, refreshInterval time.Duration) error
 	Stop()
 }
 
@@ -38,8 +38,8 @@ func (s GameType) String() string {
 
 // Make a SF6Tracker and expose it as a GameTracker
 func MakeSF6Tracker(ctx context.Context, browser *shared.Browser, username, password string, trackerRepository *data.CFNTrackerRepository) (GameTracker, error) {
-	sf6Tracker := sf6.NewSF6Tracker(ctx, browser, trackerRepository)
-	err := sf6Tracker.Authenticate(username, password, false)
+	sf6Tracker := sf6.NewSF6Tracker(browser, trackerRepository)
+	err := sf6Tracker.Authenticate(ctx, username, password, false)
 	if err != nil {
 		return nil, fmt.Errorf(`auth err: %v`, err)
 	}
@@ -49,8 +49,8 @@ func MakeSF6Tracker(ctx context.Context, browser *shared.Browser, username, pass
 
 // Make a SFVTracker and expose it as a GameTracker
 func MakeSFVTracker(ctx context.Context, browser *shared.Browser, username string, password string) (GameTracker, error) {
-	sfvTracker := sfv.NewSFVTracker(ctx, browser)
-	err := sfvTracker.Authenticate(username, password, false)
+	sfvTracker := sfv.NewSFVTracker(browser)
+	err := sfvTracker.Authenticate(ctx, username, password, false)
 	if err != nil {
 		return nil, fmt.Errorf(`auth err: %v`, err)
 	}

--- a/core/cmd.go
+++ b/core/cmd.go
@@ -45,12 +45,13 @@ func (ch *CommandHandler) GetAppVersion() string {
 }
 
 func (ch *CommandHandler) StopTracking() {
+	log.Println(`Stopped tracking`)
 	ch.tracker.Stop()
 }
 
 func (ch *CommandHandler) StartTracking(cfn string, restore bool) {
 	log.Printf(`starting tracking for %s, restoring = %v`, cfn, restore)
-	err := ch.tracker.Start(cfn, restore, RefreshInterval)
+	err := ch.tracker.Start(ch.ctx, cfn, restore, RefreshInterval)
 	if err != nil {
 		wails.EventsEmit(ch.ctx, `error-cfn`, err.Error())
 		fmt.Println(err)

--- a/core/data/match.go
+++ b/core/data/match.go
@@ -68,25 +68,26 @@ func getLogFileNameFor(displayName string, id string) string {
 func NewTrackingState(cfn string) *TrackingState {
 	return &TrackingState{
 		CFN:               cfn,
+		UserCode:          "",
 		LP:                0,
 		LPGain:            0,
 		MR:                0,
 		MRGain:            0,
 		Wins:              0,
-		Losses:            0,
 		TotalWins:         0,
 		TotalLosses:       0,
 		TotalMatches:      0,
+		Losses:            0,
 		WinRate:           0,
-		WinStreak:         0,
-		IsWin:             false,
-		TimeStamp:         ``,
-		Date:              ``,
 		Character:         ``,
 		Opponent:          ``,
 		OpponentCharacter: ``,
 		OpponentLP:        0,
 		OpponentLeague:    ``,
+		IsWin:             false,
+		TimeStamp:         ``,
+		Date:              ``,
+		WinStreak:         0,
 	}
 }
 

--- a/core/impl/sf6/auth_test.go
+++ b/core/impl/sf6/auth_test.go
@@ -16,8 +16,8 @@ func TestSF6Authentication(t *testing.T) {
 
 	ctx := context.Background()
 	browser, _ := shared.NewBrowser(ctx, true)
-	sf6Tracker := NewSF6Tracker(ctx, browser, nil)
-	err := sf6Tracker.Authenticate(os.Getenv(`CAP_ID_EMAIL`), os.Getenv(`CAP_ID_PASSWORD`), true)
+	sf6Tracker := NewSF6Tracker(browser, nil)
+	err := sf6Tracker.Authenticate(ctx, os.Getenv(`CAP_ID_EMAIL`), os.Getenv(`CAP_ID_PASSWORD`), true)
 
 	assert.Equal(nil, err)
 }

--- a/core/impl/sf6/model.go
+++ b/core/impl/sf6/model.go
@@ -1,5 +1,7 @@
 package sf6
 
+import "strconv"
+
 type PlayerInfo struct {
 	AllowCrossPlay  bool `json:"allow_cross_play"`
 	BattleInputType int  `json:"battle_input_type"`
@@ -66,497 +68,10 @@ type PlayerInfo struct {
 	BattleInputTypeName string `json:"battle_input_type_name"`
 }
 
-type BattleLog struct {
+type ProfilePage struct {
 	Props struct {
-		PageProps struct {
-			FighterBannerInfo struct {
-				AllowCrossPlay              bool `json:"allow_cross_play"`
-				BattleInputType             int  `json:"battle_input_type"`
-				CustomRoomInviteSetting     int  `json:"custom_room_invite_setting"`
-				EnjoyTotalPoint             int  `json:"enjoy_total_point"`
-				FavoriteCharacterID         int  `json:"favorite_character_id"`
-				FavoriteCharacterLeagueInfo struct {
-					LeaguePoint         int `json:"league_point"`
-					LeagueRank          int `json:"league_rank"`
-					MasterLeague        int `json:"master_league"`
-					MasterRating        int `json:"master_rating"`
-					MasterRatingRanking int `json:"master_rating_ranking"`
-					LeagueRankInfo      struct {
-						LeagueRankName   string `json:"league_rank_name"`
-						LeagueRankNumber int    `json:"league_rank_number"`
-					} `json:"league_rank_info"`
-				} `json:"favorite_character_league_info"`
-				FavoriteCharacterPlayPoint struct {
-					BattleHub      int `json:"battle_hub"`
-					FightingGround int `json:"fighting_ground"`
-					WorldTour      int `json:"world_tour"`
-				} `json:"favorite_character_play_point"`
-				FriendRequestFlag bool `json:"friend_request_flag"`
-				Friendship        int  `json:"friendship"`
-				HomeID            int  `json:"home_id"`
-				IsBeginner        bool `json:"is_beginner"`
-				IsCircleInvite    bool `json:"is_circle_invite"`
-				IsCircleMember    bool `json:"is_circle_member"`
-				LastPlayAt        int  `json:"last_play_at"`
-				MainCircle        struct {
-					CircleID   string `json:"circle_id"`
-					CircleName string `json:"circle_name"`
-					DataExist  bool   `json:"data_exist"`
-					Emblem     struct {
-						EmblemBase                       int  `json:"emblem_base"`
-						EmblemBaseColor                  int  `json:"emblem_base_color"`
-						EmblemFrame                      int  `json:"emblem_frame"`
-						EmblemFrameColor                 int  `json:"emblem_frame_color"`
-						EmblemPattern                    int  `json:"emblem_pattern"`
-						EmblemPatternColor               int  `json:"emblem_pattern_color"`
-						EmblemPatternHorizontalInversion bool `json:"emblem_pattern_horizontal_inversion"`
-						EmblemPatternVerticalInversion   bool `json:"emblem_pattern_vertical_inversion"`
-						EmblemProcessing                 int  `json:"emblem_processing"`
-						EmblemSymbol1                    int  `json:"emblem_symbol1"`
-						EmblemSymbol1Clipping            bool `json:"emblem_symbol1_clipping"`
-						EmblemSymbol1Color               int  `json:"emblem_symbol1_color"`
-						EmblemSymbol1HorizontalInversion bool `json:"emblem_symbol1_horizontal_inversion"`
-						EmblemSymbol1VerticalInversion   bool `json:"emblem_symbol1_vertical_inversion"`
-						EmblemSymbol2                    int  `json:"emblem_symbol2"`
-						EmblemSymbol2Clipping            bool `json:"emblem_symbol2_clipping"`
-						EmblemSymbol2Color               int  `json:"emblem_symbol2_color"`
-						EmblemSymbol2HorizontalInversion bool `json:"emblem_symbol2_horizontal_inversion"`
-						EmblemSymbol2VerticalInversion   bool `json:"emblem_symbol2_vertical_inversion"`
-					} `json:"emblem"`
-					Leader struct {
-						FighterID  string `json:"fighter_id"`
-						PlatformID int    `json:"platform_id"`
-						ShortID    int    `json:"short_id"`
-					} `json:"leader"`
-				} `json:"main_circle"`
-				MaxContentPlayTime struct {
-					ContentType int `json:"content_type"`
-					PlayTime    int `json:"play_time"`
-				} `json:"max_content_play_time"`
-				MobileLinkage    bool `json:"mobile_linkage"`
-				OnlineStatusInfo struct {
-					BattlehubForBeginner                       bool   `json:"battlehub_for_beginner"`
-					BattlehubID                                string `json:"battlehub_id"`
-					BattlehubPlatformID                        int    `json:"battlehub_platform_id"`
-					BattlehubRegionID                          int    `json:"battlehub_region_id"`
-					BattlehubServerNo                          int    `json:"battlehub_server_no"`
-					CustomRoomMasterShortID                    int    `json:"custom_room_master_short_id"`
-					CustomRoomPlatformID                       int    `json:"custom_room_platform_id"`
-					CustomRoomPublishSetting                   int    `json:"custom_room_publish_setting"`
-					CustomRoomRegionID                         int    `json:"custom_room_region_id"`
-					CustomRoomRequiredNetworkConnectionQuality int    `json:"custom_room_required_network_connection_quality"`
-					CustomRoomRequiredPassCode                 bool   `json:"custom_room_required_pass_code"`
-					CustomRoomRoomID                           string `json:"custom_room_room_id"`
-					OnlineStatus                               int    `json:"online_status"`
-					OnlineStatusData                           struct {
-						OnlineStatusName string `json:"online_status_name"`
-						OnlineStatusType int    `json:"online_status_type"`
-					} `json:"online_status_data"`
-					BattlehubRegionName       string `json:"battlehub_region_name"`
-					BattlehubFormatedServerNo string `json:"battlehub_formated_server_no"`
-				} `json:"online_status_info"`
-				PersonalInfo struct {
-					FighterID        string `json:"fighter_id"`
-					PlatformID       int    `json:"platform_id"`
-					ShortID          int64  `json:"short_id"`
-					PlatformName     string `json:"platform_name"`
-					PlatformToolName string `json:"platform_tool_name"`
-				} `json:"personal_info"`
-				PlayTimeZone struct {
-					EndHour     int `json:"end_hour"`
-					EndMinute   int `json:"end_minute"`
-					StartHour   int `json:"start_hour"`
-					StartMinute int `json:"start_minute"`
-				} `json:"play_time_zone"`
-				ProfileComment struct {
-					ProfileTagID     int    `json:"profile_tag_id"`
-					TagOptionID      int    `json:"tag_option_id"`
-					ProfileTagName   string `json:"profile_tag_name"`
-					ProfileTagOption string `json:"profile_tag_option"`
-				} `json:"profile_comment"`
-				TitlePlate                int    `json:"title_plate"`
-				HomeName                  string `json:"home_name"`
-				FavoriteCharacterName     string `json:"favorite_character_name"`
-				FavoriteCharacterAlpha    string `json:"favorite_character_alpha"`
-				FavoriteCharacterToolName string `json:"favorite_character_tool_name"`
-				TitleData                 struct {
-					TitleDataID        int    `json:"title_data_id"`
-					TitleDataGradeID   int    `json:"title_data_grade_id"`
-					TitleDataGradeName string `json:"title_data_grade_name"`
-					TitleDataPlateID   int    `json:"title_data_plate_id"`
-					TitleDataPlateName string `json:"title_data_plate_name"`
-					TitleDataVal       string `json:"title_data_val"`
-				} `json:"title_data"`
-				IsMyData bool `json:"is_my_data"`
-			} `json:"fighter_banner_info"`
-			CurrentPage int `json:"current_page"`
-			ReplayList  []struct {
-				BattleVersion           int        `json:"battle_version"`
-				IsRegistered            bool       `json:"is_registered"`
-				Player1Info             PlayerInfo `json:"player1_info"`
-				Player2Info             PlayerInfo `json:"player2_info"`
-				ReplayBattleSubType     int        `json:"replay_battle_sub_type"`
-				ReplayBattleType        int        `json:"replay_battle_type"`
-				ReplayID                string     `json:"replay_id"`
-				UploadedAt              int        `json:"uploaded_at"`
-				Views                   int        `json:"views"`
-				ReplayBattleTypeName    string     `json:"replay_battle_type_name"`
-				ReplayBattleSubTypeName string     `json:"replay_battle_sub_type_name"`
-			} `json:"replay_list"`
-			TotalPage int   `json:"total_page"`
-			Sid       int64 `json:"sid"`
-			WeekList  []struct {
-				Value string `json:"value"`
-				Label string `json:"label"`
-			} `json:"week_list"`
-			SeriesList []struct {
-				Value string `json:"value"`
-				Label string `json:"label"`
-				Short string `json:"short"`
-			} `json:"series_list"`
-			SnsList []struct {
-				Value string `json:"value"`
-				Label string `json:"label"`
-			} `json:"sns_list"`
-			Common struct {
-				StatusCode int  `json:"statusCode"`
-				IsError    bool `json:"isError"`
-				LoginUser  struct {
-					PlatformID int    `json:"platformId"`
-					ShortID    int64  `json:"shortId"`
-					FighterID  string `json:"fighterId"`
-					Flg        bool   `json:"flg"`
-					RegionID   int    `json:"regionId"`
-				} `json:"loginUser"`
-				AppEnv string `json:"appEnv"`
-			} `json:"common"`
-			Lang       string `json:"__lang"`
-			Namespaces struct {
-				Common struct {
-					TLangSelect                      string `json:"[t]lang-select"`
-					TTitle                           string `json:"[t]title"`
-					THeaderNavEsports                string `json:"[t]header__nav__esports"`
-					THeaderNavEsportsCpt             string `json:"[t]header__nav__esports__cpt"`
-					THeaderNavEsportsSfl             string `json:"[t]header__nav__esports__sfl"`
-					THeaderNavSupport                string `json:"[t]header__nav__support"`
-					THeaderNavSupportManual          string `json:"[t]header__nav__support__manual"`
-					THeaderNavSupportFaq             string `json:"[t]header__nav__support__faq"`
-					THeaderNavLogin                  string `json:"[t]header__nav__login"`
-					THeaderNavProfile                string `json:"[t]header__nav__profile"`
-					THeaderNavSettings               string `json:"[t]header__nav__settings"`
-					THeaderNavSettingBase            string `json:"[t]header__nav__setting__base"`
-					THeaderNavSettingProfile         string `json:"[t]header__nav__setting__profile"`
-					THeaderNavPointHistory           string `json:"[t]header__nav__point__history"`
-					THeaderNavLogout                 string `json:"[t]header__nav__logout"`
-					TBacklerNavProfile               string `json:"[t]backler__nav__profile"`
-					TBacklerNavCfn                   string `json:"[t]backler__nav__cfn"`
-					TBacklerNavInfo                  string `json:"[t]backler__nav__info"`
-					TBacklerNavMore                  string `json:"[t]backler__nav__more"`
-					TBacklerNavOther                 string `json:"[t]backler__nav__other"`
-					TBacklerNavCapcomFightersNetwork string `json:"[t]backler__nav__capcom_fighters_network"`
-					TBacklerNavFighterslist          string `json:"[t]backler__nav__fighterslist"`
-					TBacklerNavFightersclub          string `json:"[t]backler__nav__fightersclub"`
-					TBacklerNavRanking               string `json:"[t]backler__nav__ranking"`
-					TBacklerNavInformation           string `json:"[t]backler__nav__information"`
-					TBacklerNavEvent                 string `json:"[t]backler__nav__event"`
-					TBacklerNavReward                string `json:"[t]backler__nav__reward"`
-					THeaderNavOfficial               string `json:"[t]header__nav__official"`
-					THeaderNavOfficialGame           string `json:"[t]header__nav__official__game"`
-					THeaderNavOfficialGameMode       string `json:"[t]header__nav__official__game__mode"`
-					THeaderNavOfficialGameModeFg     string `json:"[t]header__nav__official__game__mode__fg"`
-					THeaderNavOfficialGameModeBh     string `json:"[t]header__nav__official__game__mode__bh"`
-					THeaderNavOfficialGameModeWt     string `json:"[t]header__nav__official__game__mode__wt"`
-					THeaderNavOfficialCharacter      string `json:"[t]header__nav__official__character"`
-					THeaderNavOfficialNews           string `json:"[t]header__nav__official__news"`
-					THeaderNavOfficialNewsAll        string `json:"[t]header__nav__official__news__all"`
-					THeaderNavOfficialNewsGame       string `json:"[t]header__nav__official__news__game"`
-					THeaderNavOfficialNewsEsports    string `json:"[t]header__nav__official__news__esports"`
-					THeaderNavOfficialNewsGoods      string `json:"[t]header__nav__official__news__goods"`
-					THeaderNavOfficialNewsEvent      string `json:"[t]header__nav__official__news__event"`
-					THeaderNavOfficialNewsCampaign   string `json:"[t]header__nav__official__news__campaign"`
-					THeaderNavOfficialColumn         string `json:"[t]header__nav__official__column"`
-					THeaderNavOfficialProduct        string `json:"[t]header__nav__official__product"`
-					THeaderNavOfficialProductMain    string `json:"[t]header__nav__official__product__main"`
-					THeaderNavOfficialProductSeason  string `json:"[t]header__nav__official__product__season"`
-					THeaderNavOfficialProductDlc     string `json:"[t]header__nav__official__product__dlc"`
-					THeaderNavSeries                 string `json:"[t]header__nav__series"`
-					TSnsTw                           string `json:"[t]sns__tw"`
-					TSnsIg                           string `json:"[t]sns__ig"`
-					TSnsYt                           string `json:"[t]sns__yt"`
-					TSnsFb                           string `json:"[t]sns__fb"`
-					TQuickNavHeadline                string `json:"[t]quick__nav__headline"`
-					TQuickNavCharacter               string `json:"[t]quick__nav__character"`
-					TPagetop                         string `json:"[t]pagetop"`
-					TYes                             string `json:"[t]yes"`
-					TNo                              string `json:"[t]no"`
-					TNext                            string `json:"[t]next"`
-					TSkip                            string `json:"[t]skip"`
-					TClose                           string `json:"[t]close"`
-					TChange                          string `json:"[t]change"`
-					TConfirm                         string `json:"[t]confirm"`
-					TCancel                          string `json:"[t]cancel"`
-					TBack                            string `json:"[t]back"`
-					TInfoListTitle                   string `json:"[t]info__list__title"`
-					TInfoListPlatformTitle           string `json:"[t]info__list__platform__title"`
-					TInfoListGenreTitle              string `json:"[t]info__list__genre__title"`
-					TInfoListGenre                   string `json:"[t]info__list__genre"`
-					TInfoListReleaseTitle            string `json:"[t]info__list__release__title"`
-					TInfoListRelease                 string `json:"[t]info__list__release"`
-					TInfoListRatingTitle             string `json:"[t]info__list__rating__title"`
-					TInfoListRatingTitleSchedule     string `json:"[t]info__list__rating__title__schedule"`
-					TInfoCaution                     string `json:"[t]info__caution"`
-					TPraise30DayDisplay              string `json:"[t]praise_30day_display"`
-					TPraisePointHistory              string `json:"[t]praise_point_history"`
-					TPraiseExit                      string `json:"[t]praise_exit"`
-					TListCrossplayActive             string `json:"[t]list_crossplay_active"`
-					TListCrossplayDisactive          string `json:"[t]list_crossplay_disactive"`
-					TCHARACTER                       string `json:"[t]CHARACTER"`
-					TABOUTUSER                       string `json:"[t]ABOUT USER"`
-					TSNS                             string `json:"[t]SNS"`
-					TPLAYINGTIME                     string `json:"[t]PLAYING TIME"`
-					T                                string `json:"[t]シリーズ歴"`
-					TNoData                          string `json:"[t]no_data"`
-					TLogin                           string `json:"[t]login"`
-					TMore                            string `json:"[t]more"`
-					TYYYYMMDDHHmm                    string `json:"[t]YYYY/MM/DD HHmm"`
-					TYYYYMMDD                        string `json:"[t]YYYY/MM/DD"`
-					TMaintenanceTitle                string `json:"[t]maintenance_title"`
-					TMaintenanceText                 string `json:"[t]maintenance_text"`
-					TMaintenanceLink                 string `json:"[t]maintenance_link"`
-					T403Title                        string `json:"[t]403_title"`
-					T403Text                         string `json:"[t]403_text"`
-					TLinksSf6                        string `json:"[t]links_sf6"`
-					TLinksBbc                        string `json:"[t]links_bbc"`
-					TLinksSeries                     string `json:"[t]links_series"`
-					TLangAll                         string `json:"[t]lang-all"`
-					TLangJaJp                        string `json:"[t]lang-ja-jp"`
-					TLangEnUs                        string `json:"[t]lang-en-us"`
-					TLangFr                          string `json:"[t]lang-fr"`
-					TLangIt                          string `json:"[t]lang-it"`
-					TLangDe                          string `json:"[t]lang-de"`
-					TLangEsEs                        string `json:"[t]lang-es-es"`
-					TLangRu                          string `json:"[t]lang-ru"`
-					TLangPl                          string `json:"[t]lang-pl"`
-					TLangPtBr                        string `json:"[t]lang-pt-br"`
-					TLangZhHant                      string `json:"[t]lang-zh-hant"`
-					TLangZhHans                      string `json:"[t]lang-zh-hans"`
-					TLangKoKr                        string `json:"[t]lang-ko-kr"`
-					TLangAr                          string `json:"[t]lang-ar"`
-					TGamemodeBattleHub               string `json:"[t]gamemode-battle_hub"`
-					TGamemodeFightingGround          string `json:"[t]gamemode-fighting_ground"`
-					TGamemodeWorldTour               string `json:"[t]gamemode-world_tour"`
-					TBrowserTimezone                 string `json:"[t]browser_timezone"`
-					TNotRegisteredRegister           string `json:"[t]not_registered_register"`
-					TNotRegisteredToWellcome         string `json:"[t]not_registered_to_wellcome"`
-					TFAVORITECHARACTER               string `json:"[t]FAVORITE CHARACTER"`
-					TSnsDc                           string `json:"[t]sns__dc"`
-					TPraiseTitleBattleHub            string `json:"[t]praise_title_battle_hub"`
-					TPraiseTitleFightingGround       string `json:"[t]praise_title_fighting_ground"`
-					TPraiseTitleWorldTour            string `json:"[t]praise_title_world_tour"`
-					TPraiseTitleWorldTogether        string `json:"[t]praise_title_world_together"`
-					TPraiseTitleView                 string `json:"[t]praise_title_view"`
-					TPraiseTitleTweet                string `json:"[t]praise_title_tweet"`
-					TPraiseTitleDeparture            string `json:"[t]praise_title_departure"`
-					TPraiseTitleEveryday             string `json:"[t]praise_title_everyday"`
-					TFooterSupportManual             string `json:"[t]footer_support_manual"`
-					TFooterSupportFaq                string `json:"[t]footer_support_faq"`
-					TFooterSupportTerms              string `json:"[t]footer_support_terms"`
-					TErrorLogin                      string `json:"[t]error_login"`
-					TIngameFooter                    string `json:"[t]ingame__footer"`
-					TLeaguePointUnit                 string `json:"[t]league_point_unit"`
-					TClubPointsUnit                  string `json:"[t]club_points_unit"`
-					TPraisePointUnit                 string `json:"[t]praise_point_unit"`
-					TBattleWin                       string `json:"[t]battle_win"`
-					TBattleLose                      string `json:"[t]battle_lose"`
-					TBattleDraw                      string `json:"[t]battle_draw"`
-					TSeparator                       string `json:"[t]separator"`
-					TAddAreaStart                    string `json:"[t]add_area_start"`
-					TSearchCharacterSelect           string `json:"[t]search_character_select"`
-					TSearchHomeArea                  string `json:"[t]search_home_area"`
-					TAddAreaEnd                      string `json:"[t]add_area_end"`
-					TDeleteAreaStart                 string `json:"[t]delete_area_start"`
-					TDeleteAreaEnd                   string `json:"[t]delete_area_end"`
-					TIngameFooter00                  string `json:"[t]ingame__footer00"`
-					TIngameFooter01                  string `json:"[t]ingame__footer01"`
-				} `json:"common"`
-				Terms struct {
-					TTermsRead   string `json:"[t]terms_read"`
-					TTermsTitle1 string `json:"[t]terms_title1"`
-					TTermsText11 string `json:"[t]terms_text1-1"`
-					TTermsText12 string `json:"[t]terms_text1-2"`
-					TTermsTitle2 string `json:"[t]terms_title2"`
-					TTermsText21 string `json:"[t]terms_text2-1"`
-					TTermsText22 string `json:"[t]terms_text2-2"`
-					TTermsTitle3 string `json:"[t]terms_title3"`
-					TTermsText31 string `json:"[t]terms_text3-1"`
-					TTermsText32 string `json:"[t]terms_text3-2"`
-					TTermsTitle4 string `json:"[t]terms_title4"`
-					TTermsText41 string `json:"[t]terms_text4-1"`
-					TTermsTitle5 string `json:"[t]terms_title5"`
-					TTermsText51 string `json:"[t]terms_text5-1"`
-					TTermsTitle6 string `json:"[t]terms_title6"`
-					TTermsText61 string `json:"[t]terms_text6-1"`
-					TTermsTitle7 string `json:"[t]terms_title7"`
-					TTermsText71 string `json:"[t]terms_text7-1"`
-					TTermsTitle8 string `json:"[t]terms_title8"`
-					TTermsText81 string `json:"[t]terms_text8-1"`
-					TTermsDate   string `json:"[t]terms_date"`
-				} `json:"terms"`
-				Error struct {
-					TTitle                 string `json:"[t]title"`
-					TDescription           string `json:"[t]description"`
-					TErrorExpiredText      string `json:"[t]error_expired_text"`
-					TErrorNoplaydataTitle  string `json:"[t]error_noplaydata_title"`
-					TErrorNoplaydataText   string `json:"[t]error_noplaydata_text"`
-					TErrorSystemText       string `json:"[t]error_system_text"`
-					TLoginReloginErrorText string `json:"[t]login_relogin_error_text"`
-					TErrorLinkFaq          string `json:"[t]error_link_faq"`
-					TErrorLinkTop          string `json:"[t]error_link_top"`
-					TLoginLogoutBtn        string `json:"[t]login_logout_btn"`
-					T404Title              string `json:"[t]404_title"`
-					T404Text               string `json:"[t]404_text"`
-					T500Title              string `json:"[t]500_title"`
-					T500Text               string `json:"[t]500_text"`
-				} `json:"error"`
-				Profile struct {
-					TTitle                          string `json:"[t]title"`
-					TDescription                    string `json:"[t]description"`
-					TProfileNavOverview             string `json:"[t]profile__nav__overview"`
-					TProfileNavPlay                 string `json:"[t]profile__nav__play"`
-					TProfileNavBattlelog            string `json:"[t]profile__nav__battlelog"`
-					TProfileNavAvatar               string `json:"[t]profile__nav__avatar"`
-					TProfileNavClub                 string `json:"[t]profile__nav__club"`
-					TPlayNavCharacter               string `json:"[t]play__nav__character"`
-					TPlayNavStyle                   string `json:"[t]play__nav__style"`
-					TBattlelogNavAll                string `json:"[t]battlelog__nav__all"`
-					TBattlelogNavRank               string `json:"[t]battlelog__nav__rank"`
-					TBattlelogNavCasual             string `json:"[t]battlelog__nav__casual"`
-					TBattlelogNavCustom             string `json:"[t]battlelog__nav__custom"`
-					TBattlelogNavHub                string `json:"[t]battlelog__nav__hub"`
-					TBattlelogNavTounament          string `json:"[t]battlelog__nav__tounament"`
-					TProfileExsist                  string `json:"[t]profile_exsist"`
-					TLeaguePointUnit                string `json:"[t]league_point_unit"`
-					TProfileMembersCard             string `json:"[t]profile_members_card"`
-					TProfileCard                    string `json:"[t]profile_card"`
-					TProfileCardShareTwitter        string `json:"[t]profile_card_share_twitter"`
-					TProfileCardShare               string `json:"[t]profile_card_share"`
-					TProfileCardShareLimit          string `json:"[t]profile_card_share_limit"`
-					TProfileCardDownload            string `json:"[t]profile_card_download"`
-					TOverviewCharacter              string `json:"[t]overview_character"`
-					TOverviewTitle                  string `json:"[t]overview_title"`
-					TOverviewInputType              string `json:"[t]overview_input_type"`
-					TOverviewPlayPoint              string `json:"[t]overview_play_point"`
-					TOverviewFg                     string `json:"[t]overview_fg"`
-					TOverviewBh                     string `json:"[t]overview_bh"`
-					TOverviewWt                     string `json:"[t]overview_wt"`
-					TOverviewLeaguePoint            string `json:"[t]overview_league_point"`
-					TOverviewMainClub               string `json:"[t]overview_main_club"`
-					TOverviewHaveCharacter          string `json:"[t]overview_have_character"`
-					TOverviewPlaytime               string `json:"[t]overview_playtime"`
-					TOverviewSeries                 string `json:"[t]overview_series"`
-					TOverviewUsesns                 string `json:"[t]overview_usesns"`
-					TOverviewSettingButton          string `json:"[t]overview_setting_button"`
-					TPlayPlaypoint                  string `json:"[t]play_playpoint"`
-					TPlayCharacterResult            string `json:"[t]play_character_result"`
-					TPlayVsCount                    string `json:"[t]play_vs_count"`
-					TPlayWinCount                   string `json:"[t]play_win_count"`
-					TPlayLoseCount                  string `json:"[t]play_lose_count"`
-					TPlayWinRate                    string `json:"[t]play_win_rate"`
-					TPlayRivalCharacterResult       string `json:"[t]play_rival_character_result"`
-					TPlayOverview                   string `json:"[t]play_overview"`
-					TPlayRankMatch                  string `json:"[t]play_rank_match"`
-					TPlayCasualMatch                string `json:"[t]play_casual_match"`
-					TPlayCustomMatch                string `json:"[t]play_custom_match"`
-					TPlayBattlehubMatch             string `json:"[t]play_battlehub_match"`
-					TPlayTargetClear                string `json:"[t]play_target_clear"`
-					TPlayEnjoy                      string `json:"[t]play_enjoy"`
-					TPlayEnjoyCount                 string `json:"[t]play_enjoy_count"`
-					TPlayEnjoyPlayer                string `json:"[t]play_enjoy_player"`
-					TPlayEnjoyFight                 string `json:"[t]play_enjoy_fight"`
-					TPlayFavorite                   string `json:"[t]play_favorite"`
-					TPlayStyleHeaderDriveRate       string `json:"[t]play_style_header_drive_rate"`
-					TPlayStyleDriveParry            string `json:"[t]play_style_drive_parry"`
-					TPlayStyleDriveImpact           string `json:"[t]play_style_drive_impact"`
-					TPlayStyleOverDriveArts         string `json:"[t]play_style_over_drive_arts"`
-					TPlayStyleParryDriveRush        string `json:"[t]play_style_parry_drive_rush"`
-					TPlayStyleCancelDriveRush       string `json:"[t]play_style_cancel_drive_rush"`
-					TPlayStyleDriveRiversal         string `json:"[t]play_style_drive_riversal"`
-					TPlayStyleDamage                string `json:"[t]play_style_damage"`
-					TPlayStyleHeaderDriveParry      string `json:"[t]play_style_header_drive_parry"`
-					TPlayStyleDriveParrySuccess     string `json:"[t]play_style_drive_parry_success"`
-					TPlayStyleDriveParryCount       string `json:"[t]play_style_drive_parry_count"`
-					TPlayStyleThrowDriveParry       string `json:"[t]play_style_throw_drive_parry"`
-					TPlayStyleDriveJustParry        string `json:"[t]play_style_drive_just_parry"`
-					TPlayStyleHeaderDriveImpact     string `json:"[t]play_style_header_drive_impact"`
-					TPlayStyleDriveImpactCount      string `json:"[t]play_style_drive_impact_count"`
-					TPlayStyleReceivesDriveImpact   string `json:"[t]play_style_receives_drive_impact"`
-					TPlayStylePunishCounter         string `json:"[t]play_style_punish_counter"`
-					TPlayStyleReceivesPunishCounter string `json:"[t]play_style_receives_punish_counter"`
-					TPlayStyleDriveImpactTo         string `json:"[t]play_style_drive_impact_to"`
-					TPlayStyleReceivedDriveImpactTo string `json:"[t]play_style_received_drive_impact_to"`
-					TPlayStyleHeaderDriveRiversal   string `json:"[t]play_style_header_drive_riversal"`
-					TPlayStyleDriveRiversalCount    string `json:"[t]play_style_drive_riversal_count"`
-					TPlayStyleHeaderSuperArtsRate   string `json:"[t]play_style_header_super_arts_rate"`
-					TPlayStyleSuperArtsRateLv1      string `json:"[t]play_style_super_arts_rate_lv1"`
-					TPlayStyleSuperArtsRateLv2      string `json:"[t]play_style_super_arts_rate_lv2"`
-					TPlayStyleSuperArtsRateLv3      string `json:"[t]play_style_super_arts_rate_lv3"`
-					TPlayStyleSuperArtsRateCa       string `json:"[t]play_style_super_arts_rate_ca"`
-					TPlayStyleHeaderThrow           string `json:"[t]play_style_header_throw"`
-					TPlayStyleThrowCount            string `json:"[t]play_style_throw_count"`
-					TPlayStyleReceievedThrow        string `json:"[t]play_style_receieved_throw"`
-					TPlayStyleThrowTech             string `json:"[t]play_style_throw_tech"`
-					TPlayStyleHeaderStun            string `json:"[t]play_style_header_stun"`
-					TPlayStyleStunCount             string `json:"[t]play_style_stun_count"`
-					TPlayStyleReceivedStun          string `json:"[t]play_style_received_stun"`
-					TPlayStyleHeaderWall            string `json:"[t]play_style_header_wall"`
-					TPlayStyleCorner                string `json:"[t]play_style_corner"`
-					TPlayStyleCounered              string `json:"[t]play_style_counered"`
-					TBattlelogReplayid              string `json:"[t]battlelog_replayid"`
-					TBattlelogReplay                string `json:"[t]battlelog_replay"`
-					TAvatarStatus                   string `json:"[t]avatar_status"`
-					TAvatarLevel                    string `json:"[t]avatar_level"`
-					TAvatarVital                    string `json:"[t]avatar_vital"`
-					TAvatarPunch                    string `json:"[t]avatar_punch"`
-					TAvatarKick                     string `json:"[t]avatar_kick"`
-					TAvatarThrow                    string `json:"[t]avatar_throw"`
-					TAvatarSpecial                  string `json:"[t]avatar_special"`
-					TAvatarDefence                  string `json:"[t]avatar_defence"`
-					TAvatarPerks                    string `json:"[t]avatar_perks"`
-					TAvatarEquip                    string `json:"[t]avatar_equip"`
-					TAvatarLooks                    string `json:"[t]avatar_looks"`
-					TAvatarArts                     string `json:"[t]avatar_arts"`
-					TAvatarGround                   string `json:"[t]avatar_ground"`
-					TAvatarAir                      string `json:"[t]avatar_air"`
-					TAvatarSuper                    string `json:"[t]avatar_super"`
-					TAvatarMaster                   string `json:"[t]avatar_master"`
-					TAvatarStyle                    string `json:"[t]avatar_style"`
-					TAvatarBond                     string `json:"[t]avatar_bond"`
-					TAvatarClasslevel               string `json:"[t]avatar_classlevel"`
-					TProfileLetsShare               string `json:"[t]profile_lets_share"`
-					TOverviewPlaytimeFormat         string `json:"[t]overview_playtime_format"`
-					TPlayCharacterSelect            string `json:"[t]play_character_select"`
-					TPlayEnjoyWinRate               string `json:"[t]play_enjoy_win_rate"`
-					TPlayStyleAverage               string `json:"[t]play_style_average"`
-					TPlayStyleDriveImpactSelf       string `json:"[t]play_style_drive_impact_self"`
-					TPlayStyleDriveImpactOppo       string `json:"[t]play_style_drive_impact_oppo"`
-					TBattlelogRound                 string `json:"[t]battlelog_round"`
-					TAvatarEquipTitle               string `json:"[t]avatar_equip_title"`
-					TNotRegisteredLead              string `json:"[t]not_registered_lead"`
-					TNotRegisteredEx1               string `json:"[t]not_registered_ex1"`
-					TNotRegisteredEx2               string `json:"[t]not_registered_ex2"`
-					TNotRegisteredEx3               string `json:"[t]not_registered_ex3"`
-					TNotRegisteredEx4               string `json:"[t]not_registered_ex4"`
-					TProfileCommentNotSetting       string `json:"[t]profile_comment_not_setting"`
-					TAvatarStylelevel               string `json:"[t]avatar_stylelevel"`
-					TSeparator                      string `json:"[t]separator"`
-					TAddAreaStart                   string `json:"[t]add_area_start"`
-					TAddAreaEnd                     string `json:"[t]add_area_end"`
-					TDeleteAreaStart                string `json:"[t]delete_area_start"`
-					TDeleteAreaEnd                  string `json:"[t]delete_area_end"`
-				} `json:"profile"`
-			} `json:"__namespaces"`
-		} `json:"pageProps"`
-		NSsp bool `json:"__N_SSP"`
+		PageProps BattleLog `json:"pageProps"`
+		NSsp      bool      `json:"__N_SSP"`
 	} `json:"props"`
 	Page  string `json:"page"`
 	Query struct {
@@ -572,6 +87,192 @@ type BattleLog struct {
 	ScriptLoader  []any    `json:"scriptLoader"`
 }
 
+type BattleLog struct {
+	FighterBannerInfo struct {
+		AllowCrossPlay              bool `json:"allow_cross_play"`
+		BattleInputType             int  `json:"battle_input_type"`
+		CustomRoomInviteSetting     int  `json:"custom_room_invite_setting"`
+		EnjoyTotalPoint             int  `json:"enjoy_total_point"`
+		FavoriteCharacterID         int  `json:"favorite_character_id"`
+		FavoriteCharacterLeagueInfo struct {
+			LeaguePoint         int `json:"league_point"`
+			LeagueRank          int `json:"league_rank"`
+			MasterLeague        int `json:"master_league"`
+			MasterRating        int `json:"master_rating"`
+			MasterRatingRanking int `json:"master_rating_ranking"`
+			LeagueRankInfo      struct {
+				LeagueRankName   string `json:"league_rank_name"`
+				LeagueRankNumber int    `json:"league_rank_number"`
+			} `json:"league_rank_info"`
+		} `json:"favorite_character_league_info"`
+		FavoriteCharacterPlayPoint struct {
+			BattleHub      int `json:"battle_hub"`
+			FightingGround int `json:"fighting_ground"`
+			WorldTour      int `json:"world_tour"`
+		} `json:"favorite_character_play_point"`
+		FriendRequestFlag bool `json:"friend_request_flag"`
+		Friendship        int  `json:"friendship"`
+		HomeID            int  `json:"home_id"`
+		IsBeginner        bool `json:"is_beginner"`
+		IsCircleInvite    bool `json:"is_circle_invite"`
+		IsCircleMember    bool `json:"is_circle_member"`
+		LastPlayAt        int  `json:"last_play_at"`
+		MainCircle        struct {
+			CircleID   string `json:"circle_id"`
+			CircleName string `json:"circle_name"`
+			DataExist  bool   `json:"data_exist"`
+			Emblem     struct {
+				EmblemBase                       int  `json:"emblem_base"`
+				EmblemBaseColor                  int  `json:"emblem_base_color"`
+				EmblemFrame                      int  `json:"emblem_frame"`
+				EmblemFrameColor                 int  `json:"emblem_frame_color"`
+				EmblemPattern                    int  `json:"emblem_pattern"`
+				EmblemPatternColor               int  `json:"emblem_pattern_color"`
+				EmblemPatternHorizontalInversion bool `json:"emblem_pattern_horizontal_inversion"`
+				EmblemPatternVerticalInversion   bool `json:"emblem_pattern_vertical_inversion"`
+				EmblemProcessing                 int  `json:"emblem_processing"`
+				EmblemSymbol1                    int  `json:"emblem_symbol1"`
+				EmblemSymbol1Clipping            bool `json:"emblem_symbol1_clipping"`
+				EmblemSymbol1Color               int  `json:"emblem_symbol1_color"`
+				EmblemSymbol1HorizontalInversion bool `json:"emblem_symbol1_horizontal_inversion"`
+				EmblemSymbol1VerticalInversion   bool `json:"emblem_symbol1_vertical_inversion"`
+				EmblemSymbol2                    int  `json:"emblem_symbol2"`
+				EmblemSymbol2Clipping            bool `json:"emblem_symbol2_clipping"`
+				EmblemSymbol2Color               int  `json:"emblem_symbol2_color"`
+				EmblemSymbol2HorizontalInversion bool `json:"emblem_symbol2_horizontal_inversion"`
+				EmblemSymbol2VerticalInversion   bool `json:"emblem_symbol2_vertical_inversion"`
+			} `json:"emblem"`
+			Leader struct {
+				FighterID  string `json:"fighter_id"`
+				PlatformID int    `json:"platform_id"`
+				ShortID    int    `json:"short_id"`
+			} `json:"leader"`
+		} `json:"main_circle"`
+		MaxContentPlayTime struct {
+			ContentType int `json:"content_type"`
+			PlayTime    int `json:"play_time"`
+		} `json:"max_content_play_time"`
+		MobileLinkage    bool `json:"mobile_linkage"`
+		OnlineStatusInfo struct {
+			BattlehubForBeginner                       bool   `json:"battlehub_for_beginner"`
+			BattlehubID                                string `json:"battlehub_id"`
+			BattlehubPlatformID                        int    `json:"battlehub_platform_id"`
+			BattlehubRegionID                          int    `json:"battlehub_region_id"`
+			BattlehubServerNo                          int    `json:"battlehub_server_no"`
+			CustomRoomMasterShortID                    int    `json:"custom_room_master_short_id"`
+			CustomRoomPlatformID                       int    `json:"custom_room_platform_id"`
+			CustomRoomPublishSetting                   int    `json:"custom_room_publish_setting"`
+			CustomRoomRegionID                         int    `json:"custom_room_region_id"`
+			CustomRoomRequiredNetworkConnectionQuality int    `json:"custom_room_required_network_connection_quality"`
+			CustomRoomRequiredPassCode                 bool   `json:"custom_room_required_pass_code"`
+			CustomRoomRoomID                           string `json:"custom_room_room_id"`
+			OnlineStatus                               int    `json:"online_status"`
+			OnlineStatusData                           struct {
+				OnlineStatusName string `json:"online_status_name"`
+				OnlineStatusType int    `json:"online_status_type"`
+			} `json:"online_status_data"`
+			BattlehubRegionName       string `json:"battlehub_region_name"`
+			BattlehubFormatedServerNo string `json:"battlehub_formated_server_no"`
+		} `json:"online_status_info"`
+		PersonalInfo struct {
+			FighterID        string `json:"fighter_id"`
+			PlatformID       int    `json:"platform_id"`
+			ShortID          int64  `json:"short_id"`
+			PlatformName     string `json:"platform_name"`
+			PlatformToolName string `json:"platform_tool_name"`
+		} `json:"personal_info"`
+		PlayTimeZone struct {
+			EndHour     int `json:"end_hour"`
+			EndMinute   int `json:"end_minute"`
+			StartHour   int `json:"start_hour"`
+			StartMinute int `json:"start_minute"`
+		} `json:"play_time_zone"`
+		ProfileComment struct {
+			ProfileTagID     int    `json:"profile_tag_id"`
+			TagOptionID      int    `json:"tag_option_id"`
+			ProfileTagName   string `json:"profile_tag_name"`
+			ProfileTagOption string `json:"profile_tag_option"`
+		} `json:"profile_comment"`
+		TitlePlate                int    `json:"title_plate"`
+		HomeName                  string `json:"home_name"`
+		FavoriteCharacterName     string `json:"favorite_character_name"`
+		FavoriteCharacterAlpha    string `json:"favorite_character_alpha"`
+		FavoriteCharacterToolName string `json:"favorite_character_tool_name"`
+		TitleData                 struct {
+			TitleDataID        int    `json:"title_data_id"`
+			TitleDataGradeID   int    `json:"title_data_grade_id"`
+			TitleDataGradeName string `json:"title_data_grade_name"`
+			TitleDataPlateID   int    `json:"title_data_plate_id"`
+			TitleDataPlateName string `json:"title_data_plate_name"`
+			TitleDataVal       string `json:"title_data_val"`
+		} `json:"title_data"`
+		IsMyData bool `json:"is_my_data"`
+	} `json:"fighter_banner_info"`
+	CurrentPage int      `json:"current_page"`
+	ReplayList  []Replay `json:"replay_list"`
+	TotalPage   int      `json:"total_page"`
+	Sid         int64    `json:"sid"`
+	WeekList    []struct {
+		Value string `json:"value"`
+		Label string `json:"label"`
+	} `json:"week_list"`
+	SeriesList []struct {
+		Value string `json:"value"`
+		Label string `json:"label"`
+		Short string `json:"short"`
+	} `json:"series_list"`
+	SnsList []struct {
+		Value string `json:"value"`
+		Label string `json:"label"`
+	} `json:"sns_list"`
+	Common struct {
+		StatusCode int  `json:"statusCode"`
+		IsError    bool `json:"isError"`
+		LoginUser  struct {
+			PlatformID int    `json:"platformId"`
+			ShortID    int64  `json:"shortId"`
+			FighterID  string `json:"fighterId"`
+			Flg        bool   `json:"flg"`
+			RegionID   int    `json:"regionId"`
+		} `json:"loginUser"`
+		AppEnv string `json:"appEnv"`
+	} `json:"common"`
+	Lang string `json:"__lang"`
+}
+
+func (bl *BattleLog) GetLP() int {
+	return bl.FighterBannerInfo.FavoriteCharacterLeagueInfo.LeaguePoint
+}
+
+func (bl *BattleLog) GetMR() int {
+	return bl.FighterBannerInfo.FavoriteCharacterLeagueInfo.MasterRating
+}
+
+func (bl *BattleLog) GetCharacter() string {
+	return bl.FighterBannerInfo.FavoriteCharacterName
+}
+
+func (bl *BattleLog) GetCFN() string {
+	return bl.FighterBannerInfo.PersonalInfo.FighterID
+}
+
+func (bl *BattleLog) GetUserCode() string {
+	return strconv.FormatInt(bl.FighterBannerInfo.PersonalInfo.ShortID, 10)
+}
+
+type Replay struct {
+	BattleVersion           int        `json:"battle_version"`
+	IsRegistered            bool       `json:"is_registered"`
+	Player1Info             PlayerInfo `json:"player1_info"`
+	Player2Info             PlayerInfo `json:"player2_info"`
+	ReplayBattleSubType     int        `json:"replay_battle_sub_type"`
+	ReplayBattleType        int        `json:"replay_battle_type"`
+	ReplayID                string     `json:"replay_id"`
+	UploadedAt              int        `json:"uploaded_at"`
+	Views                   int        `json:"views"`
+	ReplayBattleTypeName    string     `json:"replay_battle_type_name"`
+	ReplayBattleSubTypeName string     `json:"replay_battle_sub_type_name"`
+}
 type SearchResult struct {
 	AssetPrefix   string   `json:"assetPrefix"`
 	BuildID       string   `json:"buildId"`

--- a/core/impl/sf6/track.go
+++ b/core/impl/sf6/track.go
@@ -39,8 +39,6 @@ func (t *SF6Tracker) Start(ctx context.Context, userCode string, restore bool, p
 		return errors.New(`sf6 authentication err or invalid cfn`)
 	}
 
-	wails.EventsEmit(ctx, `started-tracking`)
-
 	t.state = make(map[string]*data.TrackingState, 42)
 	if restore {
 		// todo: replace with sqldb

--- a/core/impl/sfv/auth.go
+++ b/core/impl/sfv/auth.go
@@ -1,6 +1,7 @@
 package sfv
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -14,7 +15,7 @@ var (
 	ErrCaptcha = errors.New(`encountered a captcha`)
 )
 
-func (t *SFVTracker) Authenticate(username string, password string, dry bool) error {
+func (t *SFVTracker) Authenticate(ctx context.Context, username string, password string, dry bool) error {
 	fmt.Println(`Accepting CFN terms`)
 	t.Page.MustNavigate(`https://game.capcom.com/cfn/sfv/consent/steam`).MustWaitLoad()
 	t.Page.MustElement(`input[type="submit"]`).MustClick()
@@ -22,7 +23,7 @@ func (t *SFVTracker) Authenticate(username string, password string, dry bool) er
 	fmt.Println(`CFN terms accepted`)
 
 	if t.Page.MustInfo().URL == `https://game.capcom.com/cfn/sfv/` && !dry {
-		t.setInitialized()
+		t.setInitialized(ctx)
 		return nil
 	}
 
@@ -33,7 +34,7 @@ func (t *SFVTracker) Authenticate(username string, password string, dry bool) er
 	isConfirmPageOpen := t.Page.MustHas(`#imageLogin`)
 
 	if !isSteamOpen && isConfirmPageOpen && !dry {
-		t.setInitialized()
+		t.setInitialized(ctx)
 		return nil
 	}
 
@@ -84,14 +85,14 @@ func (t *SFVTracker) Authenticate(username string, password string, dry bool) er
 		}
 	}
 	if !dry {
-		t.setInitialized()
+		t.setInitialized(ctx)
 	}
 
 	return nil
 }
 
-func (t *SFVTracker) setInitialized() {
+func (t *SFVTracker) setInitialized(ctx context.Context) {
 	fmt.Println(`Gateway passed`)
 	t.isAuthenticated = true
-	wails.EventsEmit(t.ctx, `initialized`, true)
+	wails.EventsEmit(ctx, `initialized`, true)
 }

--- a/core/impl/sfv/auth_test.go
+++ b/core/impl/sfv/auth_test.go
@@ -16,8 +16,8 @@ func TestSFVAuthentication(t *testing.T) {
 
 	ctx := context.Background()
 	browser, _ := shared.NewBrowser(ctx, true)
-	sf5Tracker := NewSFVTracker(ctx, browser)
-	err := sf5Tracker.Authenticate(os.Getenv(`STEAM_USERNAME`), os.Getenv(`STEAM_PASSWORD`), true)
+	sf5Tracker := NewSFVTracker(browser)
+	err := sf5Tracker.Authenticate(ctx, os.Getenv(`STEAM_USERNAME`), os.Getenv(`STEAM_PASSWORD`), true)
 
 	assert.Equal(nil, err)
 }

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
-	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/net v0.10.0
 	golang.org/x/text v0.9.0 // indirect
 )
 

--- a/gui/src/main/app-layout/app-wrapper.tsx
+++ b/gui/src/main/app-layout/app-wrapper.tsx
@@ -20,7 +20,6 @@ export const AppWrapper: React.FC = () => {
   const [_, send] = CFNMachineContext.useActor();
 
   React.useEffect(() => {
-    EventsOn("started-tracking", () => send("startedTracking"));
     EventsOn("stopped-tracking", () => send("stoppedTracking"));
     EventsOn("auth-loaded", (percentage) => setLoaded(percentage));
     EventsOn("version-update", (hasNewVersion) => setNewVersion(hasNewVersion));
@@ -31,12 +30,13 @@ export const AppWrapper: React.FC = () => {
       setTimeout(() => setLoaded(0), 10);
     });
 
-    EventsOn("cfn-data", (matchHistory) =>
+    EventsOn("cfn-data", (matchHistory) => {
+      send("startedTracking");
       send({
         type: "matchPlayed",
         matchHistory,
-      })
-    );
+      });
+    });
 
     EventsOn("error-cfn", (error) => {
       send({


### PR DESCRIPTION
- Use a map of TrackingStates, where the `current character` is the key, instead of having additional maps for gains. 
This is overall simpler and will make restoring sessions with multiple characters an easier process when migrating to sql db.

- Simplify the canceling of the polling context. 
Before, the `Stop` function set an `isTracking` flag which isn't necessary. 

- Pass context as func params instead of having it as a field. 
The context created by wails is necessary to use `wails.EventsEmit`, and I think this should be owned by the `CommandHandler` and passed to the tracker methods that need it.

- Add getters for common props in `BattleLog` model
e.g. GetLP, GetCFN etc. 