### PR TITLE
fix: session list month offset

### DIFF
--- a/gui/src/pages/stats/sessions-list-page.tsx
+++ b/gui/src/pages/stats/sessions-list-page.tsx
@@ -53,7 +53,7 @@ export const SessionsListPage: React.FC = () => {
                     <h3 className="text-2xl mt-2">
                       {Intl.DateTimeFormat(i18n.resolvedLanguage, {
                         month: "long",
-                      }).format(new Date(`1999-${month}-01`))}
+                      }).format(new Date(`1999-${Number(month)+1}-01`))}
                     </h3>
                     <table
                       className="w-full border-spacing-y-1 border-separate"


### PR DESCRIPTION
This PR fixes date offset by -1, e.g. where month 12 is rendered as November instead of December. 

Months start at 0 in JS when calling `getMonth`  from a `Date`, but in the constructor it expects it to start at 1.

