### PR TITLE
feat: load gui config from json instead of localStorage

### DIFF
--- a/core/cmd.go
+++ b/core/cmd.go
@@ -178,6 +178,18 @@ func (ch *CommandHandler) SelectGame(game string) error {
 	return err
 }
 
+func (ch *CommandHandler) SaveLocale(locale string) error {
+	return ch.repo.SaveLocale(locale)
+}
+
+func (ch *CommandHandler) GetGuiConfig() (*model.GuiConfig, error) {
+	return ch.repo.GetGuiConfig()
+}
+
+func (ch *CommandHandler) SaveSidebarMinimized(sidebarMinified bool) error {
+	return ch.repo.SaveSidebarMinimized(sidebarMinified)
+}
+
 func (ch *CommandHandler) GetTrackingStateUnused() *model.TrackingState {
 	return nil
 }

--- a/core/data/nosql/gui_config.go
+++ b/core/data/nosql/gui_config.go
@@ -1,0 +1,29 @@
+package nosql
+
+import "fmt"
+
+func (s *Storage) SaveLocale(locale string) error {
+	cfg, err := s.GetGuiConfig()
+	if err != nil {
+		return fmt.Errorf(`failed to read config: %w`, err)
+	}
+	cfg.Locale = locale
+	err = s.writeConfig(cfg)
+	if err != nil {
+		return fmt.Errorf(`failed to save locale: %w`, err)
+	}
+	return nil
+}
+
+func (s *Storage) SaveSidebarMinimized(sidebarMinified bool) error {
+	cfg, err := s.GetGuiConfig()
+	if err != nil {
+		return fmt.Errorf(`failed to read config: %w`, err)
+	}
+	cfg.SideBarMinimized = sidebarMinified
+	err = s.writeConfig(cfg)
+	if err != nil {
+		return fmt.Errorf(`failed to save sidebarMinified: %w`, err)
+	}
+	return nil
+}

--- a/core/data/nosql/storage.go
+++ b/core/data/nosql/storage.go
@@ -1,0 +1,75 @@
+package nosql
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/williamsjokvist/cfn-tracker/core/model"
+)
+
+type Storage struct {
+	directory string
+}
+
+func NewStorage() (*Storage, error) {
+	appDataDir, err := getDocumentPath()
+	if err != nil {
+		return nil, fmt.Errorf(`get app data directory: %w`, err)
+	}
+	jsonDir := filepath.Join(appDataDir, "cfn-tracker.json")
+	storage := &Storage{
+		directory: jsonDir,
+	}
+	_, err = storage.GetGuiConfig()
+	if err != nil {
+		log.Println(err)
+		_, err = os.Create(jsonDir)
+		if err != nil {
+			log.Println(err)
+			return nil, fmt.Errorf(`create file: %w`, err)
+		}
+		err = storage.writeConfig(model.NewGuiConfig())
+		if err != nil {
+			return nil, fmt.Errorf(`failed to write initial config: %w`, err)
+		}
+	}
+	return storage, nil
+}
+
+func getDocumentPath() (string, error) {
+	cacheDir, _ := os.UserCacheDir()
+	dataDir := filepath.Join(cacheDir, "cfn-tracker")
+	err := os.MkdirAll(dataDir, os.FileMode(0755))
+	if err != nil {
+		return "", fmt.Errorf(`create directories: %w`, err)
+	}
+	return dataDir, nil
+}
+
+func (s *Storage) GetGuiConfig() (*model.GuiConfig, error) {
+	data, err := os.ReadFile(s.directory)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to read nosql db: %w`, err)
+	}
+	var cfg model.GuiConfig
+	err = json.Unmarshal(data, &cfg)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to parse nosql db: %w`, err)
+	}
+	return &cfg, nil
+}
+
+func (s *Storage) writeConfig(cfg *model.GuiConfig) error {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf(`unmarshal config: %w`, err)
+	}
+	err = os.WriteFile(s.directory, data, os.FileMode(0755))
+	if err != nil {
+		return fmt.Errorf(`failed to read nosql db: %w`, err)
+	}
+	return nil
+}

--- a/core/data/repo.go
+++ b/core/data/repo.go
@@ -5,20 +5,23 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/williamsjokvist/cfn-tracker/core/data/nosql"
 	"github.com/williamsjokvist/cfn-tracker/core/data/sql"
 	"github.com/williamsjokvist/cfn-tracker/core/data/txt"
 	"github.com/williamsjokvist/cfn-tracker/core/model"
 )
 
 type CFNTrackerRepository struct {
-	sqlDb *sql.Storage
-	txtDb *txt.Storage
+	sqlDb   *sql.Storage
+	nosqlDb *nosql.Storage
+	txtDb   *txt.Storage
 }
 
-func NewCFNTrackerRepository(sqlDb *sql.Storage, txtDb *txt.Storage) *CFNTrackerRepository {
+func NewCFNTrackerRepository(sqlDb *sql.Storage, nosqlDb *nosql.Storage, txtDb *txt.Storage) *CFNTrackerRepository {
 	return &CFNTrackerRepository{
-		sqlDb: sqlDb,
-		txtDb: txtDb,
+		sqlDb:   sqlDb,
+		nosqlDb: nosqlDb,
+		txtDb:   txtDb,
 	}
 }
 
@@ -112,4 +115,16 @@ func (m *CFNTrackerRepository) UpdateSession(ctx context.Context, sesh *model.Se
 		return fmt.Errorf("save match in storage: %w", err)
 	}
 	return nil
+}
+
+func (m *CFNTrackerRepository) SaveLocale(locale string) error {
+	return m.nosqlDb.SaveLocale(locale)
+}
+
+func (m *CFNTrackerRepository) SaveSidebarMinimized(sidebarMinified bool) error {
+	return m.nosqlDb.SaveSidebarMinimized(sidebarMinified)
+}
+
+func (m *CFNTrackerRepository) GetGuiConfig() (*model.GuiConfig, error) {
+	return m.nosqlDb.GetGuiConfig()
 }

--- a/core/model/gui_config.go
+++ b/core/model/gui_config.go
@@ -1,0 +1,13 @@
+package model
+
+type GuiConfig struct {
+	Locale           string `json:"locale"`
+	SideBarMinimized bool   `json:"sidebarMinified"`
+}
+
+func NewGuiConfig() *GuiConfig {
+	return &GuiConfig{
+		Locale:           "en-GB",
+		SideBarMinimized: false,
+	}
+}

--- a/gui/src/main/app-layout/language-selector.tsx
+++ b/gui/src/main/app-layout/language-selector.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from "react-i18next";
 import { Icon } from "@iconify/react";
 
 import { HideableText } from "@/ui/hideable-text";
-import { GetSupportedLanguages } from "@@/go/core/CommandHandler";
+import { GetSupportedLanguages, SaveLocale } from "@@/go/core/CommandHandler";
+import { useErrorMessage } from "./error-message";
 
 type LanguageSelectorProps = {
   isMinimized: boolean;
@@ -12,8 +13,8 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
   isMinimized,
 }) => {
   const { t, i18n } = useTranslation();
-
   const [langs, setLangs] = React.useState<string[]>([]);
+  const setErrorMessage = useErrorMessage();
 
   React.useEffect(() => {
     GetSupportedLanguages().then((langs) => setLangs(langs))
@@ -21,7 +22,7 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
   
   const changeLanguage = (code: string) => {
     i18n.changeLanguage(code);
-    window.localStorage.setItem("lng", code);
+    SaveLocale(code).catch(err => setErrorMessage(err))
   };
 
   return (

--- a/gui/src/main/config.tsx
+++ b/gui/src/main/config.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+
+import type { model } from "@@/go/models"
+import { GetGuiConfig } from "@@/go/core/CommandHandler"
+import { useErrorMessage } from "./app-layout/error-message"
+import { useTranslation } from "react-i18next"
+
+type ConfigContextType = [cfg: model.GuiConfig | null, setConfig: (cfg: model.GuiConfig | null) => void]
+
+const ConfigContext = React.createContext<ConfigContextType | null>(null)
+
+export const useConfig = () => React.useContext(ConfigContext)
+
+export const ConfigProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const { i18n } = useTranslation();
+  const setErrorMessage = useErrorMessage();
+  const [cfg, setCfg] = React.useState<model.GuiConfig | null>()
+  
+  React.useEffect(()=> {
+    GetGuiConfig().then(cfg => {
+      i18n.changeLanguage(cfg.locale)
+      setCfg(cfg)
+      console.log("App config:", cfg)
+    }).catch(err => setErrorMessage(err))
+  }, [])
+
+  return (
+    <ConfigContext.Provider value={[cfg, setCfg]}>
+      {children}
+    </ConfigContext.Provider>
+  )
+}

--- a/gui/src/main/i18n.ts
+++ b/gui/src/main/i18n.ts
@@ -17,7 +17,7 @@ export const initI18n = () => {
     .init<HttpBackendOptions>({
       fallbackLng: "en-GB",
       load: "currentOnly",
-      lng: window.localStorage.getItem("lng") ?? "en-GB",
+      lng: "en-GB",
       react: {
         useSuspense: true,
       },

--- a/gui/src/main/main.tsx
+++ b/gui/src/main/main.tsx
@@ -16,6 +16,8 @@ import { AppLoader } from "./app-layout/app-loader";
 import { AppWrapper } from "./app-layout/app-wrapper";
 import { AppErrorBoundary } from "./app-layout/app-error";
 import { ErrorMessageProvider } from "./app-layout/error-message";
+import { ConfigProvider } from "./config";
+
 import { initI18n } from "./i18n";
 
 import "./style.sass";
@@ -61,7 +63,9 @@ const App: React.FC = () => {
       <TrackingMachineContext.Provider>
         <React.Suspense fallback={<AppLoader/>}>
           <ErrorMessageProvider>
-            <RouterProvider router={router} />
+            <ConfigProvider>
+              <RouterProvider router={router} />
+            </ConfigProvider>
           </ErrorMessageProvider>
         </React.Suspense>
       </TrackingMachineContext.Provider>

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/williamsjokvist/cfn-tracker/core/browser"
 	"github.com/williamsjokvist/cfn-tracker/core/config"
 	"github.com/williamsjokvist/cfn-tracker/core/data"
+	"github.com/williamsjokvist/cfn-tracker/core/data/nosql"
 	"github.com/williamsjokvist/cfn-tracker/core/data/sql"
 	"github.com/williamsjokvist/cfn-tracker/core/data/txt"
 	"github.com/williamsjokvist/cfn-tracker/core/errorsx"
@@ -111,12 +112,17 @@ func main() {
 		closeWithError(fmt.Errorf(`failed to initalize database: %w`, err))
 		return
 	}
+	noSqlDb, err := nosql.NewStorage()
+	if err != nil {
+		closeWithError(fmt.Errorf(`failed to initalize app config: %w`, err))
+		return
+	}
 	txtDb, err := txt.NewStorage()
 	if err != nil {
 		closeWithError(fmt.Errorf(`failed to initalize text store: %w`, err))
 		return
 	}
-	trackerRepo := data.NewCFNTrackerRepository(sqlDb, txtDb)
+	trackerRepo := data.NewCFNTrackerRepository(sqlDb, noSqlDb, txtDb)
 	cmdHandler := core.NewCommandHandler(appBrowser, trackerRepo, &cfg)
 
 	err = wails.Run(&options.App{


### PR DESCRIPTION
Created a json database for GUI config; `locale` and `sidebarMinified` are persisted through this now instead of the browser's localStorage.