### PR TITLE
feat: save match replay id

### DIFF
--- a/gui/src/pages/matches.tsx
+++ b/gui/src/pages/matches.tsx
@@ -1,90 +1,123 @@
-import React from 'react'
-import { useLoaderData } from 'react-router-dom'
-import { useTranslation } from 'react-i18next'
+import React from "react";
+import { useLoaderData } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Icon } from '@iconify/react'
 
-import * as Page from '@/ui/page'
-import * as Table from '@/ui/table'
+import * as Page from "@/ui/page";
+import * as Table from "@/ui/table";
 
-import type { model } from '@model'
+import type { model } from "@model";
+import { Button } from "@/ui/button";
 
 export function MatchesListPage() {
-  const { t } = useTranslation()
-  const totalMatches = (useLoaderData() ?? []) as model.Match[]
-  const [matches, setMatches] = React.useState(totalMatches)
-  const [totalWinRate, setTotalWinRate] = React.useState(0)
+  const { t } = useTranslation();
+  const totalMatches = (useLoaderData() ?? []) as model.Match[];
+  const [matches, setMatches] = React.useState(totalMatches);
+  const [totalWinRate, setTotalWinRate] = React.useState(0);
 
   React.useEffect(() => {
-    const wonMatches = matches.filter(log => log.victory === true).length
-    const winRate = Math.floor((wonMatches / matches.length) * 100)
-    !isNaN(winRate) && setTotalWinRate(winRate)
-  }, [matches])
+    const wonMatches = matches.filter((log) => log.victory === true).length;
+    const winRate = Math.floor((wonMatches / matches.length) * 100);
+    !isNaN(winRate) && setTotalWinRate(winRate);
+  }, [matches]);
 
   const filterLog = (property: string, value: string) => {
-    setMatches(matches.filter(ml => ml[property].toLowerCase() === value.toLowerCase()))
-  }
+    setMatches(
+      matches.filter((ml) => ml[property].toLowerCase() === value.toLowerCase())
+    );
+  };
 
   if (matches.length === 0) {
     return (
       <Page.Root>
         <Page.Header>
-          <Page.Title>{t('history')}</Page.Title>
+          <Page.Title>{t("history")}</Page.Title>
         </Page.Header>
       </Page.Root>
-    )
+    );
   }
 
   return (
     <Page.Root>
       <Page.Header>
-        <Page.Title>{t('history')}</Page.Title>
+        <Page.Title>{t("history")}</Page.Title>
       </Page.Header>
 
-      <div className='relative w-full'>
-        <div className='mb-2 flex h-10 items-center border-b border-slate-50 border-opacity-10 px-8 pt-1 '>
+      <div className="relative w-full">
+        <div className="mb-2 flex h-10 justify-between items-center border-b border-slate-50 border-opacity-10 px-8 pt-1 ">
           <span>
-            {t('winRate')}: <b>{totalWinRate}</b>%
+            {t("winRate")}: <b>{totalWinRate}</b>%
           </span>
+          {matches.length != totalMatches.length && (
+            <Button className="py-[2px] px-1 flex gap-1 items-center" style={{ filter: 'hue-rotate(-65deg)' }} onClick={() => setMatches(totalMatches)}>
+              <Icon width={20} height={20} icon="material-symbols:chevron-left" />
+              <span className="relative top-[2px]">{t('goBack')}</span>
+            </Button>
+          )}
         </div>
         <Table.Page>
           <Table.Content>
             <thead>
               <Table.Tr>
-                <Table.Th className='w-[120px]'>{t('date')}</Table.Th>
-                <Table.Th className='w-[70px]'>{t('time')}</Table.Th>
-                <Table.Th className='w-[180px]'>{t('opponent')}</Table.Th>
-                <Table.Th>{t('league')}</Table.Th>
-                <Table.Th className='text-center'>{t('character')}</Table.Th>
-                <Table.Th className='text-center'>{t('result')}</Table.Th>
+                <Table.Th className="w-[120px]">{t("date")}</Table.Th>
+                <Table.Th className="w-[70px]">{t("time")}</Table.Th>
+                <Table.Th className="w-[180px]">{t("opponent")}</Table.Th>
+                <Table.Th>{t("league")}</Table.Th>
+                <Table.Th className="text-center">{t("character")}</Table.Th>
+                <Table.Th className="text-center">{t("result")}</Table.Th>
+                <Table.Th className="text-center">{t("replayId")}</Table.Th>
               </Table.Tr>
             </thead>
             <tbody>
-              {matches.map(log => (
+              {matches.map((log) => (
                 <Table.Tr key={`${log.date}${log.time}`}>
-                  <Table.Td interactive onClick={() => filterLog('date', log.date)}>
+                  <Table.Td
+                    interactive
+                    onClick={() => filterLog("date", log.date)}
+                  >
                     {log.date}
                   </Table.Td>
                   <Table.Td>{log.time}</Table.Td>
-                  <Table.Td interactive onClick={() => filterLog('opponent', log.opponent)}>
+                  <Table.Td
+                    interactive
+                    onClick={() => filterLog("opponent", log.opponent)}
+                  >
                     {log.opponent}
                   </Table.Td>
                   <Table.Td
                     interactive
-                    onClick={() => filterLog('opponentLeague', log.opponentLeague)}
+                    onClick={() =>
+                      filterLog("opponentLeague", log.opponentLeague)
+                    }
                   >
                     {log.opponentLeague}
                   </Table.Td>
                   <Table.Td
                     interactive
-                    className='text-center'
-                    onClick={() => filterLog('opponentCharacter', log.opponentCharacter)}
+                    className="text-center"
+                    onClick={() =>
+                      filterLog("opponentCharacter", log.opponentCharacter)
+                    }
                   >
                     {log.opponentCharacter}
                   </Table.Td>
                   <Table.Td
-                    className='text-center'
-                    style={{ color: log.victory === true ? 'lime' : 'red' }}
+                    className="text-center"
+                    style={{ color: log.victory === true ? "lime" : "red" }}
                   >
-                    {log.victory === true ? 'W' : 'L'}
+                    {log.victory === true ? "W" : "L"}
+                  </Table.Td>
+                  <Table.Td 
+                    onClick={() => navigator.clipboard.writeText(log.replayId)}
+                    className="text-center group" 
+                    interactive
+                  >
+                    <div className="z-[9999] relative inline-flex justify-center">
+                      {log.replayId}
+                      <span className="select-none z-50 group-hover:opacity-100 group-hover:visible opacity-0 invisible transition-all top-[-33px] absolute rounded-full border text-black bg-white px-2.5 py-0.5 text-xs font-semibold">
+                        {t('copy')}
+                      </span>
+                    </div>
                   </Table.Td>
                 </Table.Tr>
               ))}
@@ -93,5 +126,5 @@ export function MatchesListPage() {
         </Table.Page>
       </div>
     </Page.Root>
-  )
+  );
 }

--- a/gui/src/pages/sessions.tsx
+++ b/gui/src/pages/sessions.tsx
@@ -68,7 +68,7 @@ export function SessionsListPage() {
                         {groupedSessions[year][month].map(sesh => (
                           <Table.Tr
                             key={sesh.id}
-                            className='cursor-pointer'
+                            className='cursor-pointer group'
                             onClick={() => navigate(`/sessions/${sesh.id}/matches`)}
                           >
                             <Table.Td>

--- a/gui/src/ui/table.tsx
+++ b/gui/src/ui/table.tsx
@@ -24,7 +24,7 @@ export function Tr(props: React.PropsWithChildren<React.TdHTMLAttributes<HTMLTab
   return (
     <tr
       className={cn(
-        'group [&>*:first-child]:rounded-l-xl [&>*:last-child]:rounded-r-xl',
+        '[&>*:first-child]:rounded-l-xl [&>*:last-child]:rounded-r-xl',
         className
       )}
       {...restProps}
@@ -53,9 +53,9 @@ export function Td(
     <td
       className={cn(
         'whitespace-nowrap px-3 py-2 backdrop-blur-sm',
-        'bg-slate-50 bg-opacity-5 group-hover:bg-opacity-10',
+        'bg-white bg-opacity-5',
         'transition-colors',
-        interactive && 'cursor-pointer hover:!bg-opacity-25',
+        interactive && 'cursor-pointer hover:bg-opacity-20 active:bg-opacity-30',
         className
       )}
       {...restProps}

--- a/pkg/i18n/locales/en_GB.go
+++ b/pkg/i18n/locales/en_GB.go
@@ -25,6 +25,8 @@ var EN_GB = Localization{
 	Files:                    "Files",
 	EnterCfnName:             "Enter your CFN user code",
 	Result:                   "Result",
+	ReplayId:                 "Replay ID",
+	Copy:                     "Copy",
 	Time:                     "Time",
 	WinStreak:                "Win Streak",
 	UpdateAvailable:          "Update available!",

--- a/pkg/i18n/locales/fr_FR.go
+++ b/pkg/i18n/locales/fr_FR.go
@@ -25,6 +25,8 @@ var FR_FR = Localization{
 	Files:                    "Des dossiers",
 	EnterCfnName:             "Entrez votre nom CFN",
 	Result:                   "Dossier",
+	ReplayId:                 "Rejouer ID",
+	Copy:                     "Copie",
 	Time:                     "Temps",
 	WinStreak:                "Série de victoires",
 	UpdateAvailable:          "Nouvelle version disponible!",

--- a/pkg/i18n/locales/ja_JP.go
+++ b/pkg/i18n/locales/ja_JP.go
@@ -25,6 +25,8 @@ var JA_JP = Localization{
 	Files:                    "ファイル",
 	EnterCfnName:             "CFN名を入力してください",
 	Result:                   "結果",
+	ReplayId:                 "リプレイ",
+	Copy:                     "コピー",
 	Time:                     "時間",
 	WinStreak:                "連勝",
 	UpdateAvailable:          "アップデートが入手可能!",

--- a/pkg/i18n/locales/model.go
+++ b/pkg/i18n/locales/model.go
@@ -25,6 +25,8 @@ type Localization struct {
 	Files                    string `json:"files"`
 	EnterCfnName             string `json:"enterCfnName"`
 	Result                   string `json:"result"`
+	ReplayId                 string `json:"replayId"`
+	Copy                     string `json:"copy"`
 	Time                     string `json:"time"`
 	WinStreak                string `json:"winStreak"`
 	UpdateAvailable          string `json:"newVersionAvailable"`

--- a/pkg/model/match.go
+++ b/pkg/model/match.go
@@ -3,6 +3,7 @@ package model
 type Match struct {
 	UserId            string `db:"user_id" json:"userId"`
 	SessionId         uint16 `db:"session_id" json:"sessionId"`
+	RelayID 		  string `db:"replay_id" json:"replayId"mi`
 	Character         string `db:"character" json:"character"`
 	LP                int    `db:"lp" json:"lp"`
 	LPGain            int    `db:"lp_gain" json:"lpGain"`

--- a/pkg/model/match.go
+++ b/pkg/model/match.go
@@ -3,7 +3,7 @@ package model
 type Match struct {
 	UserId            string `db:"user_id" json:"userId"`
 	SessionId         uint16 `db:"session_id" json:"sessionId"`
-	RelayID 		  string `db:"replay_id" json:"replayId"mi`
+	ReplayID          string `db:"replay_id" json:"replayId"`
 	Character         string `db:"character" json:"character"`
 	LP                int    `db:"lp" json:"lp"`
 	LPGain            int    `db:"lp_gain" json:"lpGain"`

--- a/pkg/storage/sql/match.go
+++ b/pkg/storage/sql/match.go
@@ -36,7 +36,8 @@ func (s *Storage) SaveMatch(ctx context.Context, match model.Match) error {
 			win_streak,
 			victory,
 			date,
-			time
+			time,
+			replay_id
 		)
 		VALUES (
 			:user_id,
@@ -57,7 +58,8 @@ func (s *Storage) SaveMatch(ctx context.Context, match model.Match) error {
 			:win_streak,
 			:victory,
 			:date,
-			:time
+			:time,
+			:replay_id
 		)
 	`
 	_, err := s.db.NamedExecContext(ctx, query, match)

--- a/pkg/storage/sql/migrations/000002_add_replay_id_to_matches.down.sql
+++ b/pkg/storage/sql/migrations/000002_add_replay_id_to_matches.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE matches REMOVE COLUMN "replay_id";

--- a/pkg/storage/sql/migrations/000002_add_replay_id_to_matches.up.sql
+++ b/pkg/storage/sql/migrations/000002_add_replay_id_to_matches.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE matches ADD COLUMN "replay_id" TEXT;

--- a/pkg/storage/sql/migrations/000002_add_replay_id_to_matches.up.sql
+++ b/pkg/storage/sql/migrations/000002_add_replay_id_to_matches.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE matches ADD COLUMN "replay_id" TEXT;
+ALTER TABLE matches ADD COLUMN "replay_id" TEXT NOT NULL;

--- a/pkg/tracker/sf6/track.go
+++ b/pkg/tracker/sf6/track.go
@@ -152,14 +152,14 @@ func (t *SF6Tracker) poll(ctx context.Context, userCode string, pollRate time.Du
 			break
 		}
 
-		err = t.updateSession(ctx, userCode, bl)
+		err = t.updateSession(ctx, bl)
 		if err != nil {
 			log.Println(`failed to update session: `, err)
 		}
 	}
 }
 
-func (t *SF6Tracker) updateSession(ctx context.Context, userCode string, bl *BattleLog) error {
+func (t *SF6Tracker) updateSession(ctx context.Context, bl *BattleLog) error {
 	// no new match played
 	if t.sesh.LP == bl.GetLP() {
 		return nil

--- a/pkg/tracker/sf6/track.go
+++ b/pkg/tracker/sf6/track.go
@@ -251,7 +251,8 @@ func getOpponentInfo(myCfn string, replay *Replay) PlayerInfo {
 }
 
 func getNewestMatch(sesh *model.Session, bl *BattleLog) model.Match {
-	opponent := getOpponentInfo(bl.GetCFN(), &bl.ReplayList[0])
+	latestReplay := bl.ReplayList[0]
+	opponent := getOpponentInfo(bl.GetCFN(), latestReplay)
 	victory := !isVictory(opponent.RoundResults)
 	biota := utils.Biota(victory)
 	wins := biota
@@ -287,6 +288,7 @@ func getNewestMatch(sesh *model.Session, bl *BattleLog) model.Match {
 		WinRate:           int((float64(wins) / float64(wins+losses)) * 100),
 		UserId:            sesh.UserId,
 		SessionId:         sesh.Id,
+		ReplayID: 		   latestReplay.ReplayID,
 	}
 }
 

--- a/pkg/tracker/sf6/track.go
+++ b/pkg/tracker/sf6/track.go
@@ -252,7 +252,7 @@ func getOpponentInfo(myCfn string, replay *Replay) PlayerInfo {
 
 func getNewestMatch(sesh *model.Session, bl *BattleLog) model.Match {
 	latestReplay := bl.ReplayList[0]
-	opponent := getOpponentInfo(bl.GetCFN(), latestReplay)
+	opponent := getOpponentInfo(bl.GetCFN(), &latestReplay)
 	victory := !isVictory(opponent.RoundResults)
 	biota := utils.Biota(victory)
 	wins := biota
@@ -288,7 +288,7 @@ func getNewestMatch(sesh *model.Session, bl *BattleLog) model.Match {
 		WinRate:           int((float64(wins) / float64(wins+losses)) * 100),
 		UserId:            sesh.UserId,
 		SessionId:         sesh.Id,
-		ReplayID: 		   latestReplay.ReplayID,
+		ReplayID:          latestReplay.ReplayID,
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `ReplayID` field in match data structures to support additional identifiers related to matches.
  - Enhanced the `SaveMatch` functionality to accommodate the new `replay_id` parameter for improved match data storage.

- **Database Changes**
  - Added a `replay_id` column to the `matches` table to facilitate the storage of replay information.
  - Removed the `replay_id` column from the `matches` table, indicating a shift in data management.

- **Improvements**
  - Updated the output of the `getNewestMatch` function to include the newly added `ReplayID`, providing more detailed match replay information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->