### PR TITLE
feat: force polling for t8

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -222,6 +222,12 @@ func (ch *CommandHandler) SelectGame(game string) error {
 	return nil
 }
 
+func (ch *CommandHandler) ForcePoll() {
+	if ch.tracker != nil {
+		ch.tracker.ForcePoll()
+	}
+}
+
 func (ch *CommandHandler) SaveLocale(locale string) error {
 	return ch.nosqlDb.SaveLocale(locale)
 }

--- a/gui/src/pages/matches.tsx
+++ b/gui/src/pages/matches.tsx
@@ -9,7 +9,7 @@ import * as Table from '@/ui/table'
 import type { model } from '@model'
 import { Button } from '@/ui/button'
 import { type LocalizationKey } from '@/main/i18n'
-import { Tooltip } from '@/ui/tooltip';
+import { Tooltip } from '@/ui/tooltip'
 
 export function MatchesListPage() {
   const { t } = useTranslation()
@@ -112,7 +112,9 @@ export function MatchesListPage() {
                     interactive
                   >
                     <Tooltip text={t('copy')}>
-                      <span className="block overflow-hidden overflow-ellipsis w-12">{log.replayId}</span>
+                      <span className='block w-12 overflow-hidden overflow-ellipsis'>
+                        {log.replayId}
+                      </span>
                     </Tooltip>
                   </Table.Td>
                 </Table.Tr>

--- a/gui/src/pages/matches.tsx
+++ b/gui/src/pages/matches.tsx
@@ -9,6 +9,7 @@ import * as Table from '@/ui/table'
 import type { model } from '@model'
 import { Button } from '@/ui/button'
 import { type LocalizationKey } from '@/main/i18n'
+import { Tooltip } from '@/ui/tooltip';
 
 export function MatchesListPage() {
   const { t } = useTranslation()
@@ -110,14 +111,9 @@ export function MatchesListPage() {
                     className='group text-center'
                     interactive
                   >
-                    <div className='relative z-[9999] inline-flex justify-center'>
-                      <span className='block w-12 overflow-hidden overflow-ellipsis'>
-                        {log.replayId}
-                      </span>
-                      <span className='invisible absolute top-[-33px] z-50 select-none rounded-full border bg-white px-2.5 py-0.5 text-xs font-semibold text-black opacity-0 transition-all group-hover:visible group-hover:opacity-100'>
-                        {t('copy')}
-                      </span>
-                    </div>
+                    <Tooltip text={t('copy')}>
+                      <span className="block overflow-hidden overflow-ellipsis w-12">{log.replayId}</span>
+                    </Tooltip>
                   </Table.Td>
                 </Table.Tr>
               ))}

--- a/gui/src/pages/tracking/tracking-live-updater.tsx
+++ b/gui/src/pages/tracking/tracking-live-updater.tsx
@@ -53,7 +53,7 @@ export function TrackingLiveUpdater() {
             {mr > 0 && <SmallStat text='MR' value={`${mr == -1 ? t('placement') : mr}`} />}
           </div>
         </dl>
-        <div className='flex flex-1 h-[calc(100%-32px)] pb-5 pt-3'>
+        <div className='flex h-[calc(100%-32px)] flex-1 pb-5 pt-3'>
           <div className='w-full'>
             <dl className='whitespace-nowrap text-lg'>
               <div className='flex justify-between gap-2'>
@@ -91,7 +91,7 @@ export function TrackingLiveUpdater() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.35 }}
-            className='relative h-full flex-0 grid'
+            className='flex-0 relative grid h-full'
           >
             <PieChart
               className='mx-auto h-52 w-full'
@@ -122,7 +122,7 @@ export function TrackingLiveUpdater() {
                 </linearGradient>
               </defs>
             </PieChart>
-            <div className="flex justify-between self-end gap-2">
+            <div className='flex justify-between gap-2 self-end'>
               <Tooltip text={t('cooldown')} disabled={!refreshDisabled}>
                 <Button
                   disabled={refreshDisabled}
@@ -139,9 +139,7 @@ export function TrackingLiveUpdater() {
                   {t('refresh')}
                 </Button>
               </Tooltip>
-              <Button
-                onClick={() => trackingActor.send({ type: 'cease' })}
-              >
+              <Button onClick={() => trackingActor.send({ type: 'cease' })}>
                 <Icon icon='fa6-solid:stop' className='mr-3 h-5 w-5' />
                 {t('stop')}
               </Button>

--- a/gui/src/pages/tracking/tracking-live-updater.tsx
+++ b/gui/src/pages/tracking/tracking-live-updater.tsx
@@ -7,6 +7,7 @@ import { PieChart } from 'react-minimal-pie-chart'
 
 import { TrackingMachineContext } from '@/state/tracking-machine'
 import { Button } from '@/ui/button'
+import { Tooltip } from '@/ui/tooltip'
 import * as Page from '@/ui/page'
 import { type LocalizationKey } from '@/main/i18n'
 
@@ -52,7 +53,7 @@ export function TrackingLiveUpdater() {
             {mr > 0 && <SmallStat text='MR' value={`${mr == -1 ? t('placement') : mr}`} />}
           </div>
         </dl>
-        <div className='flex h-[calc(100%-32px)] pb-5 pt-3'>
+        <div className='flex flex-1 h-[calc(100%-32px)] pb-5 pt-3'>
           <div className='w-full'>
             <dl className='whitespace-nowrap text-lg'>
               <div className='flex justify-between gap-2'>
@@ -90,7 +91,7 @@ export function TrackingLiveUpdater() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.35 }}
-            className='relative grid h-full w-full max-w-[240px]'
+            className='relative h-full flex-0 grid'
           >
             <PieChart
               className='mx-auto h-52 w-full'
@@ -122,20 +123,22 @@ export function TrackingLiveUpdater() {
               </defs>
             </PieChart>
             <div className="flex justify-between self-end gap-2">
-              <Button
-                disabled={refreshDisabled}
-                style={{ filter: refreshDisabled ? 'grayscale(1)' : 'hue-rotate(-160deg)'}}
-                onClick={() => {
-                  if (!refreshDisabled) {
-                    trackingActor.send({ type: 'forcePoll' })
-                    setRefreshDisabled(true)
-                    setTimeout(() => setRefreshDisabled(false), 15000)
-                  }
-                }}
-              >
-                <Icon icon='fa6-solid:recycle' className='mr-3 h-5 w-5' />
-                Refresh
-              </Button>
+              <Tooltip text={t('cooldown')} disabled={!refreshDisabled}>
+                <Button
+                  disabled={refreshDisabled}
+                  style={{ filter: refreshDisabled ? 'grayscale(1)' : 'hue-rotate(-160deg)' }}
+                  onClick={() => {
+                    if (!refreshDisabled) {
+                      trackingActor.send({ type: 'forcePoll' })
+                      setRefreshDisabled(true)
+                      setTimeout(() => setRefreshDisabled(false), 15000)
+                    }
+                  }}
+                >
+                  <Icon icon='fa6-solid:recycle' className='mr-3 h-5 w-5' />
+                  {t('refresh')}
+                </Button>
+              </Tooltip>
               <Button
                 onClick={() => trackingActor.send({ type: 'cease' })}
               >

--- a/gui/src/pages/tracking/tracking-live-updater.tsx
+++ b/gui/src/pages/tracking/tracking-live-updater.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { motion } from 'framer-motion'
 import { Icon } from '@iconify/react'
 import { useTranslation } from 'react-i18next'
@@ -29,6 +30,8 @@ export function TrackingLiveUpdater() {
     opponentLeague,
     result
   } = useSelector(trackingActor, ({ context }) => context.trackingState)
+
+  const [refreshDisabled, setRefreshDisabled] = React.useState(false)
 
   return (
     <Page.Root>
@@ -118,13 +121,28 @@ export function TrackingLiveUpdater() {
                 </linearGradient>
               </defs>
             </PieChart>
-            <Button
-              className='absolute bottom-0 right-0'
-              onClick={() => trackingActor.send({ type: 'cease' })}
-            >
-              <Icon icon='fa6-solid:stop' className='mr-3 h-5 w-5' />
-              {t('stop')}
-            </Button>
+            <div className="flex justify-between self-end gap-2">
+              <Button
+                disabled={refreshDisabled}
+                style={{ filter: refreshDisabled ? 'grayscale(1)' : 'hue-rotate(-160deg)'}}
+                onClick={() => {
+                  if (!refreshDisabled) {
+                    trackingActor.send({ type: 'forcePoll' })
+                    setRefreshDisabled(true)
+                    setTimeout(() => setRefreshDisabled(false), 15000)
+                  }
+                }}
+              >
+                <Icon icon='fa6-solid:recycle' className='mr-3 h-5 w-5' />
+                Refresh
+              </Button>
+              <Button
+                onClick={() => trackingActor.send({ type: 'cease' })}
+              >
+                <Icon icon='fa6-solid:stop' className='mr-3 h-5 w-5' />
+                {t('stop')}
+              </Button>
+            </div>
           </motion.div>
         </div>
         {/* TODO: fix character image for tekken 8 */}

--- a/gui/src/state/tracking-machine.ts
+++ b/gui/src/state/tracking-machine.ts
@@ -1,7 +1,7 @@
 import { assign, setup } from 'xstate'
 import { createActorContext } from '@xstate/react'
 
-import { StartTracking, StopTracking } from '@cmd'
+import { ForcePoll, StartTracking, StopTracking } from '@cmd'
 import type { errorsx, model } from '@model'
 import { EventsOff, EventsOn } from '@runtime'
 
@@ -29,6 +29,9 @@ export const TRACKING_MACHINE = setup({
     },
     stopTracking: ({ self }) => {
       StopTracking().catch(error => self.send({ type: 'error', error }))
+    },
+    forcePoll: () => {
+      ForcePoll()
     },
     subscribeToTrackingEvents: ({ self }) => {
       EventsOn('cfn-data', trackingState => self.send({ type: 'matchPlayed', trackingState }))
@@ -90,6 +93,9 @@ export const TRACKING_MACHINE = setup({
     },
     tracking: {
       on: {
+        forcePoll: {
+          actions: ['forcePoll']
+        },
         cease: {
           actions: [
             'stopTracking',

--- a/gui/src/ui/tooltip.tsx
+++ b/gui/src/ui/tooltip.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { motion } from 'framer-motion'
+
+export function Tooltip(props: React.PropsWithChildren & {
+  text: string
+  disabled?: boolean
+}) {
+  return (
+    <div
+      className="group z-[9999] relative inline-flex justify-center"
+    >
+      {props.children}
+      {!props.disabled &&
+        <motion.span
+          key='tooltip-text'
+          className="select-none pointer-events-none z-50 group-hover:opacity-100 group-hover:visible opacity-0 invisible transition-all top-[-33px] absolute rounded-full border text-black bg-white px-2.5 pt-1 pb-0.5 text-sm font-semibold">
+          {props.text}
+        </motion.span>
+      }
+    </div>
+  )
+}

--- a/gui/src/ui/tooltip.tsx
+++ b/gui/src/ui/tooltip.tsx
@@ -1,22 +1,23 @@
 import React from 'react'
 import { motion } from 'framer-motion'
 
-export function Tooltip(props: React.PropsWithChildren & {
-  text: string
-  disabled?: boolean
-}) {
+export function Tooltip(
+  props: React.PropsWithChildren & {
+    text: string
+    disabled?: boolean
+  }
+) {
   return (
-    <div
-      className="group z-[9999] relative inline-flex justify-center"
-    >
+    <div className='group relative z-[9999] inline-flex justify-center'>
       {props.children}
-      {!props.disabled &&
+      {!props.disabled && (
         <motion.span
           key='tooltip-text'
-          className="select-none pointer-events-none z-50 group-hover:opacity-100 group-hover:visible opacity-0 invisible transition-all top-[-33px] absolute rounded-full border text-black bg-white px-2.5 pt-1 pb-0.5 text-sm font-semibold">
+          className='pointer-events-none invisible absolute top-[-33px] z-50 select-none rounded-full border bg-white px-2.5 pb-0.5 pt-1 text-sm font-semibold text-black opacity-0 transition-all group-hover:visible group-hover:opacity-100'
+        >
           {props.text}
         </motion.span>
-      }
+      )}
     </div>
   )
 }

--- a/pkg/i18n/locales/en_GB.go
+++ b/pkg/i18n/locales/en_GB.go
@@ -62,6 +62,8 @@ var EN_GB = Localization{
 	MatchesWon:               "Matches Won",
 	MatchesLost:              "Matches Lost",
 	Sessions:                 "Sessions",
+	Refresh:                  "Refresh",
+	Cooldown:                 "Cooldown",
 	T8Beginner:               "Beginner",
 	T81stDan:                 "1st Dan",
 	T82ndDan:                 "2nd Dan",

--- a/pkg/i18n/locales/fr_FR.go
+++ b/pkg/i18n/locales/fr_FR.go
@@ -62,6 +62,8 @@ var FR_FR = Localization{
 	MatchesWon:               "Matchs Gagnés",
 	MatchesLost:              "Matchs Perdus",
 	Sessions:                 "Séances",
+	Refresh:                  "Rafraîchir",
+	Cooldown:                 "Refroidir",
 	T8Beginner:               "Débutant",
 	T81stDan:                 "1er Dan",
 	T82ndDan:                 "2ème Dan",

--- a/pkg/i18n/locales/ja_JP.go
+++ b/pkg/i18n/locales/ja_JP.go
@@ -62,6 +62,8 @@ var JA_JP = Localization{
 	MatchesWon:               "勝った試合",
 	MatchesLost:              "負けた試合",
 	Sessions:                 "セッション",
+	Refresh:                  "リフレッシュ",
+	Cooldown:                 "クールダウン",
 	T8Beginner:               "入門生",
 	T81stDan:                 "初段",
 	T82ndDan:                 "二段",

--- a/pkg/i18n/locales/model.go
+++ b/pkg/i18n/locales/model.go
@@ -62,6 +62,8 @@ type Localization struct {
 	MatchesWon               string `json:"matchesWon"`
 	MatchesLost              string `json:"matchesLost"`
 	Sessions                 string `json:"sessions"`
+	Refresh                  string `json:"refresh"`
+	Cooldown                 string `json:"cooldown"`
 	T8Beginner               string `json:"T8_BEGINNER"`
 	T81stDan                 string `json:"T8_1ST_DAN"`
 	T82ndDan                 string `json:"T8_2ND_DAN"`

--- a/pkg/tracker/sf6/track.go
+++ b/pkg/tracker/sf6/track.go
@@ -321,6 +321,7 @@ func isVictory(roundResults []int) bool {
 func (t *SF6Tracker) Stop() {
 	t.stopPolling()
 }
+func (t *SF6Tracker) ForcePoll() {}
 
 func getLeagueFromLP(lp int) string {
 	if lp >= 25000 {

--- a/pkg/tracker/sfv/track.go
+++ b/pkg/tracker/sfv/track.go
@@ -100,6 +100,8 @@ func (t *SFVTracker) Start(ctx context.Context, cfn string, restoreData bool, re
 	return nil
 }
 
+func (t *SFVTracker) ForcePoll() {}
+
 func (t *SFVTracker) poll(ctx context.Context, cfn string, refreshInterval time.Duration) {
 	for {
 		didBreak := utils.SleepOrBreak(refreshInterval, func() bool {

--- a/pkg/tracker/t8/track.go
+++ b/pkg/tracker/t8/track.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
 	"time"
 
 	wails "github.com/wailsapp/wails/v2/pkg/runtime"
@@ -19,20 +21,24 @@ import (
 )
 
 type T8Tracker struct {
-	cancel     context.CancelFunc
-	wavuClient *wavu.Client
-	sqlDb      *sql.Storage
-	txtDb      *txt.Storage
+	cancel        context.CancelFunc
+	forcePollChan chan os.Signal
+	wavuClient    *wavu.Client
+	sqlDb         *sql.Storage
+	txtDb         *txt.Storage
 }
 
 var _ tracker.GameTracker = (*T8Tracker)(nil)
 
 func NewT8Tracker(sqlDb *sql.Storage, txtDb *txt.Storage) *T8Tracker {
+	var forcePollChan = make(chan os.Signal, 2)
+	signal.Notify(forcePollChan, os.Interrupt)
 	return &T8Tracker{
-		cancel:     func() {},
-		sqlDb:      sqlDb,
-		txtDb:      txtDb,
-		wavuClient: wavu.NewClient(),
+		cancel:        func() {},
+		forcePollChan: forcePollChan,
+		sqlDb:         sqlDb,
+		txtDb:         txtDb,
+		wavuClient:    wavu.NewClient(),
 	}
 }
 
@@ -48,7 +54,7 @@ func (t *T8Tracker) Start(ctx context.Context, polarisId string, restore bool, p
 			wails.EventsEmit(ctx, "cfn-data", trackingState)
 		}
 
-		go t.poll(ctx, session, polarisId, pollRate)
+		go t.poll(ctx, session, pollRate)
 		return nil
 	}
 
@@ -68,7 +74,7 @@ func (t *T8Tracker) Start(ctx context.Context, polarisId string, restore bool, p
 		return errorsx.NewFormattedError(http.StatusInternalServerError, fmt.Errorf("create session: %w", err))
 	}
 
-	go t.poll(ctx, session, polarisId, pollRate)
+	go t.poll(ctx, session, pollRate)
 	return nil
 }
 
@@ -91,7 +97,7 @@ func (t *T8Tracker) createUser(ctx context.Context, polarisId string) error {
 	return nil
 }
 
-func (t *T8Tracker) poll(ctx context.Context, session *model.Session, polarisId string, pollRate time.Duration) {
+func (t *T8Tracker) poll(ctx context.Context, session *model.Session, pollRate time.Duration) {
 	// todo: more sophisticated poll rate
 	ticker := time.NewTicker(pollRate)
 	defer func() {
@@ -105,39 +111,58 @@ func (t *T8Tracker) poll(ctx context.Context, session *model.Session, polarisId 
 	i := 0
 	for {
 		select {
+		case <-t.forcePollChan:
+			i++
+			log.Println("forced poll", i)
+			t.pollFn(ctx, session)
 		case <-ticker.C:
 			i++
 			log.Println("polling", i)
-			lastReplay, err := t.wavuClient.GetLastReplay(polarisId)
-			if err != nil {
-				return
-			}
-			var prevMatch *model.Match
-			if len(session.Matches) > 0 {
-				prevMatch = session.Matches[0]
-			}
-			if lastReplay == nil || (prevMatch != nil && prevMatch.ReplayID == lastReplay.BattleId) {
-				continue
-			}
-
-			match := getMatch(lastReplay, prevMatch, lastReplay.P2PolarisId == polarisId)
-			if match.SessionId == 0 {
-				match.SessionId = session.Id
-			}
-			session.Matches = append([]*model.Match{&match}, session.Matches...)
-			if err := t.sqlDb.SaveMatch(ctx, match); err != nil {
-				return
-			}
-
-			trackingState := model.ConvMatchToTrackingState(match)
-			wails.EventsEmit(ctx, "cfn-data", trackingState)
-			if err := t.txtDb.SaveTrackingState(&trackingState); err != nil {
-				continue
-			}
+			t.pollFn(ctx, session)
 		case <-pollCtx.Done():
 			return
 		}
 	}
+}
+
+func (t *T8Tracker) pollFn(ctx context.Context, session *model.Session) {
+	lastReplay, err := t.wavuClient.GetLastReplay(session.UserId)
+	if err != nil {
+		t.Stop()
+	}
+	var prevMatch *model.Match
+	if len(session.Matches) > 0 {
+		prevMatch = session.Matches[0]
+	}
+	if lastReplay == nil || (prevMatch != nil && prevMatch.ReplayID == lastReplay.BattleId) {
+		return
+	}
+	match := getMatch(lastReplay, prevMatch, lastReplay.P2PolarisId == session.UserId)
+	if match.SessionId == 0 {
+		match.SessionId = session.Id
+	}
+	session.Matches = append([]*model.Match{&match}, session.Matches...)
+	if err := t.sqlDb.SaveMatch(ctx, match); err != nil {
+		t.Stop()
+	}
+
+	trackingState := model.ConvMatchToTrackingState(match)
+	wails.EventsEmit(ctx, "cfn-data", trackingState)
+	if err := t.txtDb.SaveTrackingState(&trackingState); err != nil {
+		t.Stop()
+	}
+}
+
+func (t *T8Tracker) ForcePoll() {
+	t.forcePollChan <- os.Interrupt
+}
+
+func (t *T8Tracker) Stop() {
+	t.cancel()
+}
+
+func (t *T8Tracker) Authenticate(email string, password string, statChan chan tracker.AuthStatus) {
+	statChan <- tracker.AuthStatus{Progress: 100, Err: nil}
 }
 
 func getMatch(wm *wavu.Replay, prevMatch *model.Match, p2 bool) model.Match {
@@ -179,16 +204,16 @@ func getMatch(wm *wavu.Replay, prevMatch *model.Match, p2 bool) model.Match {
 
 	battleAt := time.Unix(wm.BattleAt, 0)
 	return model.Match{
-		SessionId:         sessionId,
-		UserName:          userName,
-		UserId:            polarisId,
-		Opponent:          opponent,
-		Victory:           victory,
-		ReplayID:          wm.BattleId,
-		Wins:              wins,
-		Losses:            losses,
-		WinStreak:         winStreak,
-		WinRate:           func() int {
+		SessionId: sessionId,
+		UserName:  userName,
+		UserId:    polarisId,
+		Opponent:  opponent,
+		Victory:   victory,
+		ReplayID:  wm.BattleId,
+		Wins:      wins,
+		Losses:    losses,
+		WinStreak: winStreak,
+		WinRate: func() int {
 			totalGames := wins + losses
 			if totalGames == 0 {
 				return 0
@@ -201,12 +226,4 @@ func getMatch(wm *wavu.Replay, prevMatch *model.Match, p2 bool) model.Match {
 		Date:              battleAt.Format("2006-01-02"),
 		Time:              battleAt.Format("15:04"),
 	}
-}
-
-func (t *T8Tracker) Stop() {
-	t.cancel()
-}
-
-func (t *T8Tracker) Authenticate(email string, password string, statChan chan tracker.AuthStatus) {
-	statChan <- tracker.AuthStatus{Progress: 100, Err: nil}
 }

--- a/pkg/tracker/t8/track.go
+++ b/pkg/tracker/t8/track.go
@@ -99,6 +99,7 @@ func (t *T8Tracker) poll(ctx context.Context, session *model.Session, pollRate t
 	defer func() {
 		ticker.Stop()
 		close(t.forcePollChan)
+		t.forcePollChan = nil
 		wails.EventsEmit(ctx, "stopped-tracking")
 	}()
 
@@ -151,7 +152,9 @@ func (t *T8Tracker) pollFn(ctx context.Context, session *model.Session) {
 }
 
 func (t *T8Tracker) ForcePoll() {
-	t.forcePollChan <- struct{}{}
+	if t.forcePollChan != nil {
+		t.forcePollChan <- struct{}{}
+	}
 }
 
 func (t *T8Tracker) Stop() {

--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -9,6 +9,7 @@ type GameTracker interface {
 	Start(ctx context.Context, cfn string, restore bool, refreshInterval time.Duration) error
 	Authenticate(email string, password string, statusChan chan AuthStatus)
 	Stop()
+	ForcePoll()
 }
 
 type AuthStatus struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a refresh button in the tracking live updater, allowing users to manually refresh data with a 15-second cooldown.
	- Added a new polling action to enhance the tracking functionality across various trackers.
	- Expanded the GameTracker interface to include a ForcePoll method for improved polling capabilities.
	- Implemented tooltips for replay IDs in the Matches List page for better user guidance.
	- Enhanced localization support by adding "Refresh" and "Cooldown" terms in English, French, and Japanese.

- **Bug Fixes**
	- Improved the layout of buttons in the tracking live updater for better user experience.

- **Documentation**
	- Updated public entity declarations to reflect new methods and state variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->