### PR TITLE
fix: improve first match check

### DIFF
--- a/cmd/tracking.go
+++ b/cmd/tracking.go
@@ -82,23 +82,22 @@ func (ch *TrackingHandler) StartTracking(userCode string, restore bool) error {
 		}
 
 		if user == nil {
-			usr, err := ch.gameTracker.GetUser(ctx, userCode)
+			user, err = ch.gameTracker.GetUser(ctx, userCode)
 			if err != nil {
 				return model.WrapError(model.ErrGetUser, err)
 			}
-			if err := ch.sqlDb.SaveUser(ctx, *usr); err != nil {
+			if err := ch.sqlDb.SaveUser(ctx, *user); err != nil {
 				return model.WrapError(model.ErrSaveUser, err)
 			}
 		}
 
-		sesh, err := ch.sqlDb.CreateSession(ctx, userCode)
+		session, err = ch.sqlDb.CreateSession(ctx, userCode)
 		if err != nil {
 			return model.WrapError(model.ErrCreateSession, err)
 		}
-		session = sesh
-		// session.LP = bl.GetLP()
-		// session.MR = bl.GetMR()
-		// session.UserName = bl.GetCFN()
+		session.LP = user.LP
+		session.MR = user.MR
+		session.UserName = user.DisplayName
 	}
 
 	if session == nil {

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -4,4 +4,6 @@ type User struct {
 	Id          uint8  `db:"id" json:"id"`
 	DisplayName string `db:"display_name" json:"displayName"`
 	Code        string `db:"code" json:"code"`
+	LP          int
+	MR          int
 }

--- a/pkg/tracker/sf6/cfn/model.go
+++ b/pkg/tracker/sf6/cfn/model.go
@@ -268,7 +268,7 @@ type Replay struct {
 	ReplayBattleSubType     int        `json:"replay_battle_sub_type"`
 	ReplayBattleType        int        `json:"replay_battle_type"`
 	ReplayID                string     `json:"replay_id"`
-	UploadedAt              int        `json:"uploaded_at"`
+	UploadedAt              int64      `json:"uploaded_at"`
 	Views                   int        `json:"views"`
 	ReplayBattleTypeName    string     `json:"replay_battle_type_name"`
 	ReplayBattleSubTypeName string     `json:"replay_battle_sub_type_name"`

--- a/pkg/tracker/sf6/track.go
+++ b/pkg/tracker/sf6/track.go
@@ -53,7 +53,7 @@ func (t *SF6Tracker) Poll(ctx context.Context, cancel context.CancelFunc, sessio
 	}
 
 	battleAt := time.Unix(lastReplay.UploadedAt, 0)
-	if time.Now().Sub(battleAt).Hours() >= 24 {
+	if time.Since(battleAt).Hours() >= 24 {
 		return
 	}
 

--- a/pkg/tracker/sf6/track.go
+++ b/pkg/tracker/sf6/track.go
@@ -30,6 +30,8 @@ func (t *SF6Tracker) GetUser(ctx context.Context, userCode string) (*model.User,
 	return &model.User{
 		DisplayName: bl.GetCFN(),
 		Code:        userCode,
+		LP:          bl.GetLP(),
+		MR:          bl.GetMR(),
 	}, nil
 }
 
@@ -49,10 +51,19 @@ func (t *SF6Tracker) Poll(ctx context.Context, cancel context.CancelFunc, sessio
 	if session.LP == bl.GetLP() || prevMatch.ReplayID == lastReplay.ReplayID {
 		return
 	}
-	latestReplay := bl.ReplayList[0]
-	opponent := getOpponentInfo(bl.GetCFN(), &latestReplay)
-	victory := !isVictory(opponent.RoundResults)
 
+	battleAt := time.Unix(lastReplay.UploadedAt, 0)
+	if time.Now().Sub(battleAt).Hours() >= 24 {
+		return
+	}
+
+	var opponent cfn.PlayerInfo
+	if bl.GetCFN() == lastReplay.Player1Info.Player.FighterID {
+		opponent = lastReplay.Player2Info
+	} else {
+		opponent = lastReplay.Player1Info
+	}
+	victory := !isVictory(opponent.RoundResults)
 	wins := prevMatch.Wins
 	losses := prevMatch.Losses
 	winStreak := prevMatch.WinStreak
@@ -85,16 +96,8 @@ func (t *SF6Tracker) Poll(ctx context.Context, cancel context.CancelFunc, sessio
 		UserId:            session.UserId,
 		UserName:          session.UserName,
 		SessionId:         session.Id,
-		ReplayID:          latestReplay.ReplayID,
+		ReplayID:          lastReplay.ReplayID,
 	})
-}
-
-func getOpponentInfo(myCfn string, replay *cfn.Replay) cfn.PlayerInfo {
-	if myCfn == replay.Player1Info.Player.FighterID {
-		return replay.Player2Info
-	} else {
-		return replay.Player1Info
-	}
 }
 
 func getPreviousMatchForCharacter(sesh *model.Session, character string) model.Match {

--- a/pkg/tracker/t8/track.go
+++ b/pkg/tracker/t8/track.go
@@ -42,7 +42,7 @@ func (t *T8Tracker) GetUser(ctx context.Context, polarisId string) (*model.User,
 }
 
 func (t *T8Tracker) Poll(ctx context.Context, cancel context.CancelFunc, session *model.Session, onNewMatch func(model.Match)) {
-	wm, err := t.wavuClient.GetLastReplay(ctx, session.UserId)
+	lastReplay, err := t.wavuClient.GetLastReplay(ctx, session.UserId)
 	if err != nil {
 		cancel()
 	}
@@ -50,26 +50,29 @@ func (t *T8Tracker) Poll(ctx context.Context, cancel context.CancelFunc, session
 	if len(session.Matches) > 0 {
 		prevMatch = *session.Matches[0]
 	}
-	if wm == nil || prevMatch.ReplayID == wm.BattleId {
+	if lastReplay == nil || prevMatch.ReplayID == lastReplay.BattleId {
 		return
 	}
-	battleAt := time.Unix(wm.BattleAt, 0)
-	polarisId := wm.P1PolarisId
-	userName := wm.P1Name
-	character := wm.P1CharaId
-	opponentCharacter := wm.P2CharaId
-	victory := wm.Winner == 1
-	opponent := wm.P2Name
-	opponentRank := wm.P2Rank
+	battleAt := time.Unix(lastReplay.BattleAt, 0)
+	if time.Now().Sub(battleAt).Hours() >= 24 {
+		return
+	}
+	polarisId := lastReplay.P1PolarisId
+	userName := lastReplay.P1Name
+	character := lastReplay.P1CharaId
+	opponentCharacter := lastReplay.P2CharaId
+	victory := lastReplay.Winner == 1
+	opponent := lastReplay.P2Name
+	opponentRank := lastReplay.P2Rank
 
-	if wm.P2PolarisId == session.UserId {
-		polarisId = wm.P2PolarisId
-		userName = wm.P2Name
-		character = wm.P2CharaId
-		opponentCharacter = wm.P1CharaId
-		victory = wm.Winner == 2
-		opponent = wm.P1Name
-		opponentRank = wm.P1Rank
+	if lastReplay.P2PolarisId == session.UserId {
+		polarisId = lastReplay.P2PolarisId
+		userName = lastReplay.P2Name
+		character = lastReplay.P2CharaId
+		opponentCharacter = lastReplay.P1CharaId
+		victory = lastReplay.Winner == 2
+		opponent = lastReplay.P1Name
+		opponentRank = lastReplay.P1Rank
 	}
 
 	wins := prevMatch.Wins
@@ -89,7 +92,7 @@ func (t *T8Tracker) Poll(ctx context.Context, cancel context.CancelFunc, session
 		UserId:    polarisId,
 		Opponent:  opponent,
 		Victory:   victory,
-		ReplayID:  wm.BattleId,
+		ReplayID:  lastReplay.BattleId,
 		Wins:      wins,
 		Losses:    losses,
 		WinStreak: winStreak,

--- a/pkg/tracker/t8/track.go
+++ b/pkg/tracker/t8/track.go
@@ -54,7 +54,7 @@ func (t *T8Tracker) Poll(ctx context.Context, cancel context.CancelFunc, session
 		return
 	}
 	battleAt := time.Unix(lastReplay.BattleAt, 0)
-	if time.Now().Sub(battleAt).Hours() >= 24 {
+	if time.Since(battleAt).Hours() >= 24 {
 		return
 	}
 	polarisId := lastReplay.P1PolarisId


### PR DESCRIPTION
A session's first match will not be counted if the last match was played more than a day ago. Also fixed initial assigning of username, LP, MR on fresh sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added League Points (LP) and Master Rating (MR) to user profile
	- Enhanced replay tracking with 24-hour match processing limit

- **Bug Fixes**
	- Improved opponent identification in match tracking
	- Updated timestamp handling for replay uploads

- **Refactor**
	- Streamlined user and session data management
	- Simplified match processing logic across tracking systems
	- Updated data types for improved precision in replay timestamps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->